### PR TITLE
add device and pinned pools and use it in benches

### DIFF
--- a/libcudf-datafusion/Cargo.toml
+++ b/libcudf-datafusion/Cargo.toml
@@ -2,10 +2,7 @@
 name = "libcudf-datafusion"
 version = "0.1.0"
 edition = "2021"
-authors = [
-    "notfilippo",
-    "gabotechs",
-]
+authors = ["notfilippo", "gabotechs"]
 
 [dependencies]
 libcudf-rs = { path = ".." }
@@ -35,18 +32,13 @@ dirs = { version = "6", optional = true }
 
 [features]
 integration = [
-    "insta",
-    "tpchgen",
-    "tpchgen-arrow",
-    "parquet",
-    "pretty_assertions",
+  "insta",
+  "tpchgen",
+  "tpchgen-arrow",
+  "parquet",
+  "pretty_assertions",
 ]
-cli = [
-    "clap",
-    "datafusion-cli",
-    "env_logger",
-    "dirs",
-]
+cli = ["clap", "datafusion-cli", "env_logger", "dirs"]
 tpch = ["integration"]
 
 [dev-dependencies]
@@ -70,6 +62,10 @@ name = "join"
 harness = false
 
 [[bench]]
+name = "load_unload"
+harness = false
+
+[[bench]]
 name = "tpch_pipeline"
 harness = false
 
@@ -77,4 +73,3 @@ harness = false
 name = "cli"
 path = "bin/cli.rs"
 required-features = ["cli"]
-

--- a/libcudf-datafusion/benches/aggregate.rs
+++ b/libcudf-datafusion/benches/aggregate.rs
@@ -8,7 +8,7 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_physical_plan::{execute_stream, ExecutionPlan};
 use futures_util::TryStreamExt;
 use libcudf_datafusion::aggregate::{avg, count, max, min, sum};
-use libcudf_datafusion::{CuDFConfig, HostToCuDFRule};
+use libcudf_datafusion::{configure_default_pools, CuDFConfig, HostToCuDFRule};
 use std::hint::black_box;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -84,6 +84,7 @@ async fn build_plan(ctx: &SessionContext, sql: &str) -> Arc<dyn ExecutionPlan> {
 }
 
 fn bench_group(c: &mut Criterion, group_name: &str, sql: &str) {
+    configure_default_pools();
     let rt = Runtime::new().unwrap();
     let mut group = c.benchmark_group(group_name);
 

--- a/libcudf-datafusion/benches/join.rs
+++ b/libcudf-datafusion/benches/join.rs
@@ -2,7 +2,9 @@ use arrow::array::{Int32Array, Int64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use libcudf_rs::{inner_join, left_join, left_semi_join, CuDFTable, CuDFTableView};
+use libcudf_rs::{
+    configure_default_pools, inner_join, left_join, left_semi_join, CuDFTable, CuDFTableView,
+};
 use std::hint::black_box;
 use std::sync::Arc;
 
@@ -51,6 +53,7 @@ fn gpu_views(left_n: usize, right_m: usize) -> (CuDFTableView, CuDFTableView) {
 }
 
 fn bench_inner_join(c: &mut Criterion) {
+    configure_default_pools();
     let mut group = c.benchmark_group("join/inner");
 
     for &(left_n, right_m) in SIZES {

--- a/libcudf-datafusion/benches/load_unload.rs
+++ b/libcudf-datafusion/benches/load_unload.rs
@@ -1,0 +1,194 @@
+use arrow::array::*;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use datafusion::execution::TaskContext;
+use datafusion_physical_plan::test::TestMemoryExec;
+use datafusion_physical_plan::{execute_stream, ExecutionPlan};
+use futures_util::TryStreamExt;
+use libcudf_datafusion::{configure_default_pools, CuDFLoadExec, CuDFUnloadExec};
+use std::hint::black_box;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+const SIZES: &[usize] = &[100_000, 1_000_000, 10_000_000];
+
+fn make_cpu_batches(total_rows: usize) -> Vec<RecordBatch> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("orderkey", DataType::Int64, false),
+        Field::new("custkey", DataType::Int64, false),
+        Field::new("orderstatus", DataType::Utf8, false),
+        Field::new("totalprice", DataType::Float64, false),
+        Field::new("orderdate", DataType::Int32, false),
+        Field::new("orderpriority", DataType::Utf8, false),
+        Field::new("clerk", DataType::Utf8, false),
+        Field::new("shippriority", DataType::Int32, false),
+        Field::new("comment", DataType::Utf8, false),
+    ]));
+    let batch_size = 8192;
+    let mut batches = Vec::new();
+    let mut offset = 0;
+    while offset < total_rows {
+        let len = batch_size.min(total_rows - offset);
+        batches.push(
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(Int64Array::from_iter_values(0..len as i64)),
+                    Arc::new(Int64Array::from_iter_values(0..len as i64)),
+                    Arc::new(StringArray::from(vec!["O"; len])),
+                    Arc::new(Float64Array::from_iter_values((0..len).map(|i| i as f64))),
+                    Arc::new(Int32Array::from_iter_values(0..len as i32)),
+                    Arc::new(StringArray::from(vec!["3-MEDIUM"; len])),
+                    Arc::new(StringArray::from(vec!["Clerk#000000001"; len])),
+                    Arc::new(Int32Array::from_iter_values(vec![0i32; len])),
+                    Arc::new(StringArray::from(vec!["comment"; len])),
+                ],
+            )
+            .unwrap(),
+        );
+        offset += len;
+    }
+    batches
+}
+
+fn load_plan(batches: Vec<RecordBatch>) -> Arc<dyn ExecutionPlan> {
+    let schema = batches[0].schema();
+    let mem = Arc::new(TestMemoryExec::try_new(&[batches], schema, None).unwrap());
+    Arc::new(CuDFLoadExec::try_new(mem).unwrap())
+}
+
+fn unload_plan(gpu_batches: Vec<RecordBatch>) -> Arc<dyn ExecutionPlan> {
+    let schema = gpu_batches[0].schema();
+    let mem = Arc::new(TestMemoryExec::try_new(&[gpu_batches], schema, None).unwrap());
+    Arc::new(CuDFUnloadExec::new(mem))
+}
+
+async fn drain(plan: Arc<dyn ExecutionPlan>) {
+    let ctx = Arc::new(TaskContext::default());
+    black_box(
+        execute_stream(plan, ctx)
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap(),
+    );
+}
+
+fn gpu_batches(rt: &Runtime, total_rows: usize) -> Vec<RecordBatch> {
+    rt.block_on(async {
+        let ctx = Arc::new(TaskContext::default());
+        execute_stream(load_plan(make_cpu_batches(total_rows)), ctx)
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap()
+    })
+}
+
+// Unpooled benchmarks must run first, pools are one-time global state.
+
+fn bench_load_unpooled(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("load");
+    for &total_rows in SIZES {
+        let batches = make_cpu_batches(total_rows);
+        let bytes: usize = batches.iter().map(|b| b.get_array_memory_size()).sum();
+        group.throughput(Throughput::Bytes(bytes as u64));
+        group.bench_with_input(
+            BenchmarkId::new("unpooled", total_rows),
+            &total_rows,
+            |b, _| {
+                b.iter_batched(
+                    || load_plan(batches.clone()),
+                    |plan| rt.block_on(drain(plan)),
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_unload_unpooled(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("unload");
+    for &total_rows in SIZES {
+        let batches = gpu_batches(&rt, total_rows);
+        let bytes: usize = make_cpu_batches(total_rows)
+            .iter()
+            .map(|b| b.get_array_memory_size())
+            .sum();
+        group.throughput(Throughput::Bytes(bytes as u64));
+        group.bench_with_input(
+            BenchmarkId::new("unpooled", total_rows),
+            &total_rows,
+            |b, _| {
+                b.iter_batched(
+                    || unload_plan(batches.clone()),
+                    |plan| rt.block_on(drain(plan)),
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_load_pooled(c: &mut Criterion) {
+    configure_default_pools();
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("load");
+    for &total_rows in SIZES {
+        let batches = make_cpu_batches(total_rows);
+        let bytes: usize = batches.iter().map(|b| b.get_array_memory_size()).sum();
+        group.throughput(Throughput::Bytes(bytes as u64));
+        group.bench_with_input(
+            BenchmarkId::new("pooled", total_rows),
+            &total_rows,
+            |b, _| {
+                b.iter_batched(
+                    || load_plan(batches.clone()),
+                    |plan| rt.block_on(drain(plan)),
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_unload_pooled(c: &mut Criterion) {
+    // pools already configured by bench_load_pooled
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("unload");
+    for &total_rows in SIZES {
+        let batches = gpu_batches(&rt, total_rows);
+        let bytes: usize = make_cpu_batches(total_rows)
+            .iter()
+            .map(|b| b.get_array_memory_size())
+            .sum();
+        group.throughput(Throughput::Bytes(bytes as u64));
+        group.bench_with_input(
+            BenchmarkId::new("pooled", total_rows),
+            &total_rows,
+            |b, _| {
+                b.iter_batched(
+                    || unload_plan(batches.clone()),
+                    |plan| rt.block_on(drain(plan)),
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_load_unpooled,
+    bench_unload_unpooled,
+    bench_load_pooled,
+    bench_unload_pooled
+);
+criterion_main!(benches);

--- a/libcudf-datafusion/benches/tpch_pipeline.rs
+++ b/libcudf-datafusion/benches/tpch_pipeline.rs
@@ -41,7 +41,7 @@ use datafusion::prelude::{ParquetReadOptions, SessionConfig, SessionContext};
 use datafusion_physical_plan::{execute_stream, ExecutionPlan};
 use futures_util::TryStreamExt;
 use libcudf_datafusion::aggregate::count;
-use libcudf_datafusion::{CuDFConfig, HostToCuDFRule};
+use libcudf_datafusion::{configure_default_pools, CuDFConfig, HostToCuDFRule};
 use std::hint::black_box;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -125,6 +125,7 @@ async fn build_plan(ctx: &SessionContext, sql: &str) -> Arc<dyn ExecutionPlan> {
 }
 
 fn bench_tpch_pipeline(c: &mut Criterion) {
+    configure_default_pools();
     let rt = Runtime::new().unwrap();
     let mut group = c.benchmark_group("tpch_pipeline/orders_x_customer");
 

--- a/libcudf-datafusion/src/lib.rs
+++ b/libcudf-datafusion/src/lib.rs
@@ -12,4 +12,8 @@ mod physical;
 #[cfg(any(feature = "integration", test))]
 pub mod test_utils;
 
+pub use libcudf_rs::configure_default_pools;
+pub use libcudf_rs::DevicePoolConfig;
+pub use libcudf_rs::PinnedPoolConfig;
 pub use optimizer::{CuDFConfig, HostToCuDFRule};
+pub use physical::{CuDFLoadExec, CuDFUnloadExec};

--- a/libcudf-datafusion/src/physical/cudf_load.rs
+++ b/libcudf-datafusion/src/physical/cudf_load.rs
@@ -8,7 +8,7 @@ use datafusion::physical_expr::EquivalenceProperties;
 use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use futures_util::stream::StreamExt;
-use libcudf_rs::{is_cudf_array, CuDFColumn};
+use libcudf_rs::{is_cudf_array, CuDFTable};
 use std::any::Any;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -87,21 +87,19 @@ impl ExecutionPlan for CuDFLoadExec {
                 Err(err) => return Err(err),
             };
 
-            // TODO(#20): replace per-column upload with a single CuDFTable::from_arrow_host call
-            // see https://github.com/gene-bordegaray/libcudf-rs/issues/20
-            let original_cols = batch.columns();
-            let mut cudf_cols: Vec<Arc<dyn Array>> = Vec::with_capacity(original_cols.len());
-            for original_col in original_cols {
-                if is_cudf_array(original_col) {
-                    return exec_err!(
-                        "Cannot move RecordBatch from host to CuDF: a column is already a CuDF array"
-                    );
-                }
-                let col = CuDFColumn::from_arrow_host(original_col).map_err(cudf_to_df)?;
-                cudf_cols.push(Arc::new(col.into_view()));
+            if batch.columns().iter().any(|c| is_cudf_array(c)) {
+                return exec_err!(
+                    "Cannot move RecordBatch from host to CuDF: a column is already a CuDF array"
+                );
             }
-
-            Ok(RecordBatch::try_new(batch.schema(), cudf_cols)?)
+            let schema = batch.schema();
+            let table = CuDFTable::from_arrow_host(batch).map_err(cudf_to_df)?;
+            let cudf_cols: Vec<Arc<dyn Array>> = table
+                .into_columns()
+                .into_iter()
+                .map(|c| Arc::new(c.into_view()) as Arc<dyn Array>)
+                .collect();
+            Ok(RecordBatch::try_new(schema, cudf_cols)?)
         });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),

--- a/libcudf-datafusion/src/physical/cudf_unload.rs
+++ b/libcudf-datafusion/src/physical/cudf_unload.rs
@@ -1,13 +1,13 @@
 use crate::errors::cudf_to_df;
 use arrow::array::RecordBatch;
 use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
-use datafusion::common::{exec_err, internal_datafusion_err, plan_err, DataFusionError};
+use datafusion::common::{plan_err, DataFusionError};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use futures_util::StreamExt;
-use libcudf_rs::CuDFColumnView;
+use libcudf_rs::CuDFTableView;
 use std::any::Any;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -86,24 +86,15 @@ impl ExecutionPlan for CuDFUnloadExec {
                 Err(err) => return Err(err),
             };
 
-            let original_cols = batch.columns();
-            let mut host_cols = Vec::with_capacity(original_cols.len());
-            for (i, original_col) in original_cols.iter().enumerate() {
-                let Some(cudf_col) = original_col.as_any().downcast_ref::<CuDFColumnView>() else {
-                    return exec_err!(
-                        "Cannot move RecordBatch from CuDF to host: a column is not a CuDF array"
-                    );
-                };
-                let arr = cudf_col.to_arrow_host().map_err(cudf_to_df)?;
-                let target_field = target_schema
-                    .fields
-                    .get(i)
-                    .ok_or_else(|| internal_datafusion_err!("Could not find field {i}"))?;
-
-                let arr = arrow::compute::cast(&arr, target_field.data_type())?;
-                host_cols.push((target_field.name(), arr))
-            }
-            RecordBatch::try_from_iter(host_cols).map_err(|err| {
+            let view = CuDFTableView::from_record_batch(&batch).map_err(cudf_to_df)?;
+            let host_batch = view.to_arrow_host().map_err(cudf_to_df)?;
+            let columns = host_batch
+                .columns()
+                .iter()
+                .zip(target_schema.fields())
+                .map(|(col, field)| arrow::compute::cast(col, field.data_type()))
+                .collect::<Result<Vec<_>, _>>()?;
+            RecordBatch::try_new(target_schema.clone(), columns).map_err(|err| {
                 DataFusionError::ArrowError(
                     Box::new(err),
                     Some("Error while unloading a RecordBatch from CuDF into host".to_string()),

--- a/libcudf-sys/build.rs
+++ b/libcudf-sys/build.rs
@@ -55,6 +55,7 @@ fn main() {
         .include(OUT_DIR.join("libcudf").join("include").join("rapids"))
         .include(OUT_DIR.join("librmm").join("include"))
         .include(OUT_DIR.join("librmm").join("include").join("rapids"))
+        .include(OUT_DIR.join("rapids_logger").join("include"))
         .include(OUT_DIR.join("libkvikio").join("include"))
         // Include shared libraries from the CUDA installation present in the system
         .include(CUDA_ROOT.join("include"))
@@ -243,6 +244,7 @@ fn setup_library_paths(lib_dir: &Path, project_root: &Path) {
     println!("cargo:rustc-link-lib=dylib=cudart");
     println!("cargo:rustc-link-lib=dylib=rmm");
     println!("cargo:rustc-link-lib=dylib=kvikio");
+    println!("cargo:rustc-link-lib=dylib=rapids_logger");
 
     // Set rpath
     println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");

--- a/libcudf-sys/src/lib.rs
+++ b/libcudf-sys/src/lib.rs
@@ -577,6 +577,28 @@ pub mod ffi {
 
         /// Get the version of the cuDF library
         fn get_cudf_version() -> String;
+
+        /// Configure the global RMM device-memory pool.
+        ///
+        /// Reserves `initial_bytes` of GPU VRAM via `cudaMalloc` once at startup so that
+        /// `rmm::device_buffer` allocations (every cuDF column buffer) are served from the
+        /// pool instead of calling `cudaMalloc` per allocation. Returns `true` if the pool
+        /// was configured, `false` if already set by a previous call.
+        fn config_device_memory_pool(initial_bytes: usize, max_bytes: usize) -> bool;
+
+        /// Configure the global cuDF pinned-memory pool.
+        ///
+        /// Reserves `pool_size_bytes` of page-locked host RAM via `cudaMallocHost`
+        /// once so that subsequent host↔GPU copies bypass CUDA's internal pageable
+        /// staging copy. Returns `true` if the pool was configured, `false` if it
+        /// was already set up by a previous call.
+        fn config_pinned_memory_resource(pool_size_bytes: usize) -> bool;
+
+        /// Set the minimum allocation size that will be served from the pinned pool.
+        ///
+        /// Allocations smaller than `threshold_bytes` remain as ordinary pageable
+        /// memory. Only allocations at or above the threshold use the pinned pool.
+        fn set_host_pinned_threshold(threshold_bytes: usize);
     }
 }
 

--- a/libcudf-sys/src/operations.cpp
+++ b/libcudf-sys/src/operations.cpp
@@ -7,7 +7,12 @@
 #include <cudf/copying.hpp>
 #include <cudf/interop.hpp>
 #include <cudf/stream_compaction.hpp>
+#include <cudf/utilities/pinned_memory.hpp>
 #include <cudf/version_config.hpp>
+
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
 
 #include <nanoarrow/nanoarrow.h>
 
@@ -115,6 +120,25 @@ namespace libcudf_bridge {
                 << CUDF_VERSION_MINOR << "."
                 << CUDF_VERSION_PATCH;
         return {version.str()};
+    }
+
+    bool config_device_memory_pool(size_t initial_bytes, size_t max_bytes) {
+        static std::unique_ptr<rmm::mr::cuda_memory_resource> base_mr;
+        static std::unique_ptr<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>> pool_mr;
+        if (pool_mr) return false;
+        base_mr = std::make_unique<rmm::mr::cuda_memory_resource>();
+        pool_mr = std::make_unique<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>>(
+            base_mr.get(), initial_bytes, max_bytes);
+        rmm::mr::set_current_device_resource(pool_mr.get());
+        return true;
+    }
+
+    bool config_pinned_memory_resource(size_t pool_size_bytes) {
+        return cudf::config_default_pinned_memory_resource({.pool_size = pool_size_bytes});
+    }
+
+    void set_host_pinned_threshold(size_t threshold_bytes) {
+        cudf::set_allocate_host_as_pinned_threshold(threshold_bytes);
     }
 
     // Arrow interop - convert Arrow data to cuDF table

--- a/libcudf-sys/src/operations.h
+++ b/libcudf-sys/src/operations.h
@@ -32,4 +32,11 @@ namespace libcudf_bridge {
 
     // Utility functions
     rust::String get_cudf_version();
+
+    // Pinned-memory pool configuration
+    bool config_pinned_memory_resource(size_t pool_size_bytes);
+    void set_host_pinned_threshold(size_t threshold_bytes);
+
+    // Device-memory pool configuration
+    bool config_device_memory_pool(size_t initial_bytes, size_t max_bytes);
 } // namespace libcudf_bridge

--- a/src/device_pool.rs
+++ b/src/device_pool.rs
@@ -1,0 +1,111 @@
+/// Configuration for the RMM GPU device-memory pool.
+///
+/// A pre-reserved slab of GPU VRAM allocated once at startup. Every cuDF column
+/// buffer is backed by an `rmm::device_buffer` which draws from this slab. Freed
+/// buffers are returned immediately and reused by the next batch with no driver
+/// involvement.
+///
+/// ## Without pool
+///
+/// For each column in a batch, before any data transfer begins:
+///
+/// 1. cuDF calls `cudaMalloc(size)` to back the `rmm::device_buffer`
+/// 2. GPU driver acquires a global mutex
+/// 3. Driver walks the virtual address tree to find a free region
+/// 4. Driver updates page tables and returns a pointer
+/// 5. Steps 1–4 repeat for every column, serially
+/// 6. On batch teardown, `cudaFree` is called for every column (another driver round-trip each)
+///
+/// ```text
+/// col 0:  [cudaMalloc] [DMA col0 ----------]
+/// col 1:               [cudaMalloc] [DMA col1 ----------]
+/// col 2:                            [cudaMalloc] [DMA col2 ----------]
+/// ```
+///
+/// ## With pool
+///
+/// The slab is reserved once at [`apply`] time. For each column in a batch:
+///
+/// 1. cuDF calls `pool.alloc(size)` - pointer bump into the slab (no driver call)
+/// 2. DMA transfer begins immediately
+/// 3. On teardown, `pool.free()` returns the slot to the slab (no driver call)
+/// 4. The next batch reuses the same slots
+///
+/// ```text
+/// startup:  [cudaMalloc once -----------------------------------------]
+///
+/// batch N:  [alloc x cols] [DMA col0 --][DMA col1 --][DMA col2 --]
+/// batch N+1:[alloc x cols] [DMA col0 --][DMA col1 --][DMA col2 --]
+/// ```
+///
+/// # When to use
+///
+/// Enable for any workload that processes many batches. The `cudaMalloc` cost is
+/// paid per column per batch on both allocation and free.
+///
+/// For one-shot queries the benefit is marginal. On shared GPU servers
+/// always set `max_size` to leave headroom. Without a cap the pool can grow to
+/// exhaust all available VRAM.
+///
+/// # Usage
+///
+/// Call [`apply`] once before running any GPU operations. See also
+/// [`configure_default_pools`](crate::configure_default_pools) for a
+/// single-call shorthand using the default values.
+///
+/// ```rust,no_run
+/// use libcudf_rs::DevicePoolConfig;
+///
+/// DevicePoolConfig {
+///     initial_size: 4 * 1024 * 1024 * 1024,
+///     max_size:     8 * 1024 * 1024 * 1024,
+/// }.apply();
+/// ```
+pub struct DevicePoolConfig {
+    /// Bytes of GPU VRAM to reserve upfront via a single `cudaMalloc`.
+    ///
+    /// The pool pre-allocates this slab when [`apply`] is called. If the slab fills
+    /// up, the pool grows by calling `cudaMalloc` again until [`max_size`] is reached.
+    ///
+    /// Set to at least your pipeline's peak working set (the sum of all live column
+    /// buffers across concurrent batches). Sizing below this causes growth pauses during
+    /// warm-up.
+    pub initial_size: usize,
+
+    /// Hard cap in bytes on total pool VRAM.
+    ///
+    /// The pool will not grow beyond this. If an allocation would exceed it,
+    /// cuDF throws `std::bad_alloc`. Set this to leave headroom for other GPU
+    /// workloads sharing the same device.
+    ///
+    /// Must be at least `initial_size`.
+    pub max_size: usize,
+}
+
+impl Default for DevicePoolConfig {
+    /// Conservative defaults suitable for GPU analytics workloads.
+    ///
+    /// - `initial_size`: 512 MB
+    /// - `max_size`: 4 GB
+    ///
+    /// Override `initial_size` upward if your pipeline's peak working set exceeds
+    /// 512 MB to avoid growth pauses during warm-up.
+    fn default() -> Self {
+        Self {
+            initial_size: 512 * 1024 * 1024,  // 512 MB
+            max_size: 4 * 1024 * 1024 * 1024, //   4 GB
+        }
+    }
+}
+
+impl DevicePoolConfig {
+    /// Apply this configuration globally for the current process.
+    ///
+    /// Must be called before any cuDF operations run.
+    ///
+    /// Returns `true` if the pool was configured, `false` if already set by
+    /// a previous call.
+    pub fn apply(&self) -> bool {
+        libcudf_sys::ffi::config_device_memory_pool(self.initial_size, self.max_size)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,12 @@ mod column_view;
 mod cudf_array;
 mod cudf_reference;
 mod data_type;
+mod device_pool;
 mod errors;
 mod group_by;
 mod join;
 mod operations;
+mod pinned_pool;
 mod scalar;
 mod sort;
 mod table;
@@ -37,14 +39,26 @@ pub use column::CuDFColumn;
 pub use column_view::CuDFColumnView;
 pub use cudf_array::*;
 pub use cudf_reference::CuDFRef;
+pub use device_pool::DevicePoolConfig;
 pub use errors::{CuDFError, Result};
 pub use group_by::*;
 pub use join::{cross_join, full_join, inner_join, left_anti_join, left_join, left_semi_join};
 pub use operations::{apply_boolean_mask, cast, gather, slice_column};
+pub use pinned_pool::PinnedPoolConfig;
 pub use scalar::CuDFScalar;
 pub use sort::{sort, sort_by_all, stable_sorted_order, SortOrder};
 pub use table::*;
 pub use table_view::*;
+
+/// Configure default memory pools for GPU-accelerated workloads.
+///
+/// Equivalent to calling [`PinnedPoolConfig::default().apply()`] and
+/// [`DevicePoolConfig::default().apply()`]. Call once before executing
+/// any GPU operations. See each config type to override pool sizes.
+pub fn configure_default_pools() {
+    PinnedPoolConfig::default().apply();
+    DevicePoolConfig::default().apply();
+}
 
 /// Get cuDF version information
 ///

--- a/src/pinned_pool.rs
+++ b/src/pinned_pool.rs
@@ -1,0 +1,118 @@
+/// Configuration for cuDF's pinned host-memory pool.
+///
+/// A fixed-size pool of page-locked (pinned) host RAM reserved once at startup.
+/// cuDF draws from this pool for its internal host allocations, intermediate buffers,
+/// and output staging on the download path (GPU -> host), instead of calling
+/// `cudaMallocHost` per operation. Pinned memory can be DMA'd directly by the GPU
+/// without the CUDA runtime needing to stage through a temporary buffer first.
+///
+/// The pool primarily benefits the download path where cuDF owns the destination
+/// allocation. On the upload path, the Arrow source buffer is the user's pageable
+/// memory and is unaffected by this pool.
+///
+/// ## Without pool
+///
+/// For each column in a batch, on a single CUDA stream:
+///
+/// 1. cuDF calls `cudaMemcpyAsync(gpu_dst, arrow_ptr, size, Default, stream)`
+/// 2. CUDA detects the source is pageable and cannot DMA it directly
+/// 3. CUDA runtime stages the data internally through its own pinned staging buffer:
+///    - CPU copies data to the staging buffer (CPU blocks)
+///    - DMA enqueued for that chunk on stream
+///    - CPU waits for DMA before reusing the staging buffer
+///    - Repeats until the full column is transferred
+/// 4. Steps 1–3 repeat for every column, serially
+///
+/// ```text
+/// CPU  [--stage--][----wait----][--stage--][----wait----] col 0 done [--stage--]...
+/// PCIe            [DMA transfer]           [DMA transfer]
+/// ```
+///
+/// ## With pool
+///
+/// cuDF's internal host allocations come from the pre-locked slab. With a pinned
+/// destination, CUDA issues a single DMA per column with no staging:
+///
+/// 1. cuDF allocates destination buffer from the pinned slab (pointer bump, no OS call)
+/// 2. `cudaMemcpyAsync` sees a pinned destination and enqueues one DMA
+/// 3. CPU returns from the call instantly (no staging, no blocking)
+///
+/// ```text
+/// CPU  [alloc][enqueue] [alloc][enqueue] [alloc][enqueue]
+/// PCIe [----- DMA col0 -----][----- DMA col1 -----][----- DMA col2 -----]
+/// ```
+///
+/// # When to use
+///
+/// Enable for workloads where batches exceed ~1 MB per column as the staging
+/// overhead is paid per column per batch.
+///
+/// Disable for workloads with small batches where the pool reservation cost
+/// exceeds the savings.
+///
+/// # Usage
+///
+/// Call [`apply`] once before running any GPU operations. See also
+/// [`configure_default_pools`](crate::configure_default_pools) for a
+/// single-call shorthand using the default values.
+///
+/// ```rust,no_run
+/// use libcudf_rs::PinnedPoolConfig;
+///
+/// PinnedPoolConfig {
+///     pool_size: 512 * 1024 * 1024,
+///     threshold:   1 * 1024 * 1024,
+/// }.apply();
+/// ```
+pub struct PinnedPoolConfig {
+    /// Bytes of page-locked host RAM to reserve upfront.
+    ///
+    /// The pool is fixed-size, both the initial and maximum capacity are set to this
+    /// value. If exhausted, cuDF falls back to a non-pooled pinned allocation rather
+    /// than growing or erroring.
+    ///
+    /// Paid once at [`apply`] time. All subsequent cuDF internal host allocations
+    /// draw from this slab with no OS calls and no per-allocation page locking.
+    ///
+    /// Pinned memory is page-locked and cannot be swapped, so it reduces the
+    /// pageable RAM available to the rest of the system. Size conservatively on
+    /// shared or memory-constrained hosts.
+    pub pool_size: usize,
+
+    /// Allocations up to this size (bytes) use the pinned pool. Larger ones stay pageable.
+    ///
+    /// cuDF's built-in default is 0, meaning all host allocations are pageable unless
+    /// this is set. 1 MB is a good starting point for analytics workloads; lower it
+    /// if your columns are typically smaller than 1 MB per batch.
+    pub threshold: usize,
+}
+
+impl Default for PinnedPoolConfig {
+    /// Conservative defaults suitable for GPU analytics workloads.
+    ///
+    /// - `pool_size`: 512 MB
+    /// - `threshold`: 1 MB
+    ///
+    /// Override `pool_size` upward if your batches regularly exceed 256 MB per column,
+    /// or downward on memory-constrained hosts.
+    fn default() -> Self {
+        Self {
+            pool_size: 512 * 1024 * 1024, // 512 MB
+            threshold: 1 * 1024 * 1024,   //   1 MB - smaller allocs stay pageable
+        }
+    }
+}
+
+impl PinnedPoolConfig {
+    /// Apply this configuration globally for the current process.
+    ///
+    /// Must be called before any cuDF operations run.
+    ///
+    /// Returns `true` if the pool was configured, `false` if already set by
+    /// a previous call (the threshold is still updated).
+    pub fn apply(&self) -> bool {
+        let configured = libcudf_sys::ffi::config_pinned_memory_resource(self.pool_size);
+        libcudf_sys::ffi::set_host_pinned_threshold(self.threshold);
+        configured
+    }
+}


### PR DESCRIPTION
this speeds up loads speeds a lot because cuDF owns the destination allocation which now is largely done upfront chepa therefore after