### PR TITLE
Gene.bordegaray/2026/03/fix decimail precision conversions

### DIFF
--- a/libcudf-datafusion/src/aggregate/mod.rs
+++ b/libcudf-datafusion/src/aggregate/mod.rs
@@ -487,10 +487,19 @@ mod integration {
     /// AVG produces Float64 — uses assert_batches_approx_eq to handle last-ULP differences.
     #[tokio::test]
     async fn test_avg() -> Result<(), Box<dyn Error>> {
-        let sql = r#"SELECT "RainToday", AVG("MinTemp") as avg_min FROM weather GROUP BY "RainToday""#;
+        let sql =
+            r#"SELECT "RainToday", AVG("MinTemp") as avg_min FROM weather GROUP BY "RainToday""#;
         let tf = TestFramework::new().await;
-        let gpu = tf.execute(&format!("SET cudf.enable=true; SET datafusion.execution.target_partitions=1; {sql}")).await?;
-        let cpu = tf.execute(&format!("SET datafusion.execution.target_partitions=1; {sql}")).await?;
+        let gpu = tf
+            .execute(&format!(
+                "SET cudf.enable=true; SET datafusion.execution.target_partitions=1; {sql}"
+            ))
+            .await?;
+        let cpu = tf
+            .execute(&format!(
+                "SET datafusion.execution.target_partitions=1; {sql}"
+            ))
+            .await?;
         assert_batches_approx_eq(&sort_batches(&gpu.batches), &sort_batches(&cpu.batches), 10);
         assert_snapshot!(gpu.plan, @"
         CuDFUnloadExec
@@ -535,8 +544,16 @@ mod integration {
     async fn test_multiple_aggregates() -> Result<(), Box<dyn Error>> {
         let sql = r#"SELECT "RainToday", COUNT("Rainfall") as n, SUM("Rainfall") as total, AVG("MaxTemp") as avg_max, MIN("MinTemp") as lo, MAX("MaxTemp") as hi FROM weather GROUP BY "RainToday""#;
         let tf = TestFramework::new().await;
-        let gpu = tf.execute(&format!("SET cudf.enable=true; SET datafusion.execution.target_partitions=1; {sql}")).await?;
-        let cpu = tf.execute(&format!("SET datafusion.execution.target_partitions=1; {sql}")).await?;
+        let gpu = tf
+            .execute(&format!(
+                "SET cudf.enable=true; SET datafusion.execution.target_partitions=1; {sql}"
+            ))
+            .await?;
+        let cpu = tf
+            .execute(&format!(
+                "SET datafusion.execution.target_partitions=1; {sql}"
+            ))
+            .await?;
         assert_batches_approx_eq(&sort_batches(&gpu.batches), &sort_batches(&cpu.batches), 10);
         assert_snapshot!(gpu.plan, @"
         CuDFUnloadExec
@@ -599,7 +616,8 @@ mod integration {
 
     #[tokio::test]
     async fn test_multi_partition_sum() -> Result<(), Box<dyn Error>> {
-        let sql = r#"SELECT "RainToday", SUM("Rainfall") as total FROM weather GROUP BY "RainToday""#;
+        let sql =
+            r#"SELECT "RainToday", SUM("Rainfall") as total FROM weather GROUP BY "RainToday""#;
         let result = check_query_results(sql, 4).await?;
         assert_snapshot!(result.plan, @"
         CuDFUnloadExec
@@ -646,8 +664,16 @@ mod integration {
     async fn test_multi_partition_multiple_aggs() -> Result<(), Box<dyn Error>> {
         let sql = r#"SELECT "RainToday", COUNT(*) as n, SUM("Rainfall") as total, AVG("MaxTemp") as avg_max, MIN("MinTemp") as lo, MAX("MaxTemp") as hi FROM weather GROUP BY "RainToday""#;
         let tf = TestFramework::new().await;
-        let gpu = tf.execute(&format!("SET cudf.enable=true; SET datafusion.execution.target_partitions=4; {sql}")).await?;
-        let cpu = tf.execute(&format!("SET datafusion.execution.target_partitions=4; {sql}")).await?;
+        let gpu = tf
+            .execute(&format!(
+                "SET cudf.enable=true; SET datafusion.execution.target_partitions=4; {sql}"
+            ))
+            .await?;
+        let cpu = tf
+            .execute(&format!(
+                "SET datafusion.execution.target_partitions=4; {sql}"
+            ))
+            .await?;
         assert_batches_approx_eq(&sort_batches(&gpu.batches), &sort_batches(&cpu.batches), 10);
         assert_snapshot!(gpu.plan, @"
         CuDFUnloadExec
@@ -674,7 +700,10 @@ mod integration {
         let sql = r#"SELECT "RainToday", BOOL_OR("RainTomorrow" = 'Yes') as any_rain FROM weather GROUP BY "RainToday""#;
         let gpu = tf.execute(&format!("SET cudf.enable=true; {sql}")).await?;
         let cpu = tf.execute(sql).await?;
-        assert!(!gpu.plan.contains("CuDFAggregateExec"), "expected CPU fallback");
+        assert!(
+            !gpu.plan.contains("CuDFAggregateExec"),
+            "expected CPU fallback"
+        );
         assert_eq!(cpu.pretty_print, gpu.pretty_print);
         Ok(())
     }

--- a/libcudf-datafusion/src/aggregate/stream.rs
+++ b/libcudf-datafusion/src/aggregate/stream.rs
@@ -12,7 +12,9 @@ use datafusion_physical_plan::aggregates::{
 };
 use datafusion_physical_plan::udaf::AggregateFunctionExpr;
 use futures::{ready, StreamExt};
-use libcudf_rs::{CuDFColumn, CuDFColumnView, CuDFGroupBy, CuDFTable, CuDFTableView};
+use libcudf_rs::{
+    record_batch_with_schema, CuDFColumn, CuDFColumnView, CuDFGroupBy, CuDFTable, CuDFTableView,
+};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -303,10 +305,7 @@ impl Stream {
             }
         }
 
-        Ok(Some(RecordBatch::try_new(
-            self.output_schema.clone(),
-            arrays,
-        )?))
+        Ok(Some(record_batch_with_schema(arrays, &self.output_schema)?))
     }
 
     /// Evaluate GROUP BY expressions on a batch and wrap the resulting key
@@ -386,7 +385,7 @@ fn concat_cudf_batches(batches: &[RecordBatch]) -> Result<RecordBatch> {
             Ok(Arc::new(col.into_view()) as Arc<dyn Array>)
         })
         .collect::<Result<Vec<_>>>()?;
-    Ok(RecordBatch::try_new(schema, cols)?)
+    Ok(record_batch_with_schema(cols, &schema)?)
 }
 
 impl futures::Stream for Stream {

--- a/libcudf-datafusion/src/expr/binary.rs
+++ b/libcudf-datafusion/src/expr/binary.rs
@@ -1,6 +1,6 @@
 use crate::errors::cudf_to_df;
 use crate::expr::{columnar_value_to_cudf, cudf_to_columnar_value, expr_to_cudf_expr};
-use arrow::array::{AsArray, RecordBatch};
+use arrow::array::RecordBatch;
 use arrow_schema::{DataType, FieldRef, Schema};
 use datafusion::common::DataFusionError;
 use datafusion::logical_expr::ColumnarValue;
@@ -67,49 +67,21 @@ impl PhysicalExpr for CuDFBinaryExpr {
     }
 
     fn evaluate(&self, batch: &RecordBatch) -> datafusion::common::Result<ColumnarValue> {
-        // Get BOTH the expected output type (from host) AND the CuDF output type (normalized precision)
-        let expected_output_type = self.data_type(batch.schema_ref())?;
+        let expected = self.data_type(batch.schema_ref())?;
 
-        // For CuDF binary op, use normalized decimal precision (38)
-        let cudf_output_type = match &expected_output_type {
+        // cuDF requires max precision for decimal output types.
+        let cudf_output_type = match &expected {
             DataType::Decimal128(_, scale) => DataType::Decimal128(38, *scale),
             DataType::Decimal32(_, scale) => DataType::Decimal32(9, *scale),
             DataType::Decimal64(_, scale) => DataType::Decimal64(18, *scale),
-            _ => expected_output_type.clone(),
+            _ => expected.clone(),
         };
 
-        let lhs = self.left.evaluate(batch)?;
-        let lhs = columnar_value_to_cudf(lhs)?;
-        let rhs = self.right.evaluate(batch)?;
-        let rhs = columnar_value_to_cudf(rhs)?;
+        let lhs = columnar_value_to_cudf(self.left.evaluate(batch)?)?;
+        let rhs = columnar_value_to_cudf(self.right.evaluate(batch)?)?;
 
         let result = cudf_binary_op(lhs, rhs, self.op, &cudf_output_type).map_err(cudf_to_df)?;
-        let mut result = cudf_to_columnar_value(result);
-
-        // CuDF returns decimals with maximum precision (38), but DataFusion may expect a different precision.
-        // Cast the result if needed to match the expected output type.
-        if let ColumnarValue::Array(arr) = &result {
-            if arr.data_type() != &expected_output_type {
-                if let (
-                    DataType::Decimal128(_, result_scale),
-                    DataType::Decimal128(_expected_prec, expected_scale),
-                ) = (arr.data_type(), &expected_output_type)
-                {
-                    if result_scale == expected_scale {
-                        // Same scale, just different precision. Arrow's cast doesn't handle this,
-                        // so we manually change the precision metadata while keeping the same i128 values.
-                        let decimal_array = arr.as_primitive::<arrow::datatypes::Decimal128Type>();
-                        let casted = decimal_array
-                            .clone()
-                            .with_precision_and_scale(*_expected_prec, *expected_scale)
-                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-                        result = ColumnarValue::Array(Arc::new(casted));
-                    }
-                }
-            }
-        }
-
-        Ok(result)
+        Ok(cudf_to_columnar_value(result))
     }
 
     fn with_new_children(

--- a/libcudf-datafusion/src/physical/coalesce_batches.rs
+++ b/libcudf-datafusion/src/physical/coalesce_batches.rs
@@ -386,7 +386,9 @@ impl CuDFBatchCoalescer {
 
         // Convert back to record batch
         let concat_view = concat_table.into_view();
-        let concat_batch = concat_view.to_record_batch().map_err(cudf_to_df)?;
+        let concat_batch = concat_view
+            .to_record_batch_with_schema(&self.schema)
+            .map_err(cudf_to_df)?;
 
         // Split at target_batch_size
         let output_batch = concat_batch.slice(0, self.target_batch_size);
@@ -433,7 +435,9 @@ impl CuDFBatchCoalescer {
 
         let concat_table = CuDFTable::concat(table_views).map_err(cudf_to_df)?;
         let concat_view = concat_table.into_view();
-        let concat_batch = concat_view.to_record_batch().map_err(cudf_to_df)?;
+        let concat_batch = concat_view
+            .to_record_batch_with_schema(&self.schema)
+            .map_err(cudf_to_df)?;
 
         self.completed.push(concat_batch);
         self.buffered_batches.clear();

--- a/libcudf-datafusion/src/physical/cudf_load.rs
+++ b/libcudf-datafusion/src/physical/cudf_load.rs
@@ -99,7 +99,7 @@ impl ExecutionPlan for CuDFLoadExec {
                 .into_iter()
                 .map(|c| Arc::new(c.into_view()) as Arc<dyn Array>)
                 .collect();
-            Ok(RecordBatch::try_new(schema, cudf_cols)?)
+            Ok(libcudf_rs::record_batch_with_schema(cudf_cols, &schema)?)
         });
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),
@@ -117,11 +117,7 @@ pub(crate) fn normalize_scalar_for_cudf(value: ScalarValue) -> ScalarValue {
     }
 }
 
-/// Maps an Arrow schema to the types cuDF will actually produce.
-///
-/// - `Utf8View -> Utf8`: cuDF's `TYPE_STRING` has no view variant.
-/// - `Decimal{32,64,128}(p, s) -> Decimal{32,64,128}(max_p, s)`: cuDF uses fixed precision
-///   based on storage width (9/18/38). Scale is preserved.
+/// Maps an Arrow schema to cuDF-compatible types (`Utf8View -> Utf8`).
 pub(crate) fn cudf_schema_compatibility_map(schema: SchemaRef) -> SchemaRef {
     let mut new_fields = Vec::with_capacity(schema.fields.len());
 
@@ -130,21 +126,6 @@ pub(crate) fn cudf_schema_compatibility_map(schema: SchemaRef) -> SchemaRef {
             DataType::Utf8View => FieldRef::new(Field::new(
                 field.name(),
                 DataType::Utf8,
-                field.is_nullable(),
-            )),
-            DataType::Decimal32(_, s) => FieldRef::new(Field::new(
-                field.name(),
-                DataType::Decimal32(9, *s), // max precision for 32-bit
-                field.is_nullable(),
-            )),
-            DataType::Decimal64(_, s) => FieldRef::new(Field::new(
-                field.name(),
-                DataType::Decimal64(18, *s), // max precision for 64-bit
-                field.is_nullable(),
-            )),
-            DataType::Decimal128(_, s) => FieldRef::new(Field::new(
-                field.name(),
-                DataType::Decimal128(38, *s), // max precision for 128-bit
                 field.is_nullable(),
             )),
             _ => Arc::clone(field),

--- a/libcudf-datafusion/src/physical/filter.rs
+++ b/libcudf-datafusion/src/physical/filter.rs
@@ -203,21 +203,18 @@ fn filter_and_project(
     }
 
     // Apply projection if needed
-    if let Some(projection) = projection {
-        let projected_columns: Vec<Arc<dyn Array>> = projection
+    let columns = if let Some(projection) = projection {
+        projection
             .iter()
             .map(|i| Arc::clone(&cudf_columns[*i]))
-            .collect();
-        Ok(RecordBatch::try_new(
-            Arc::clone(output_schema),
-            projected_columns,
-        )?)
+            .collect()
     } else {
-        Ok(RecordBatch::try_new(
-            Arc::clone(output_schema),
-            cudf_columns,
-        )?)
-    }
+        cudf_columns
+    };
+    Ok(libcudf_rs::record_batch_with_schema(
+        columns,
+        output_schema,
+    )?)
 }
 
 // Implementation pretty much copied from `datafusion/core/src/physical_plan/filter.rs`

--- a/libcudf-datafusion/src/physical/projection.rs
+++ b/libcudf-datafusion/src/physical/projection.rs
@@ -170,15 +170,11 @@ impl CuDFProjectionStream {
         if arrays.is_empty() {
             let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
             RecordBatch::try_new_with_options(Arc::clone(&self.schema), arrays, &options)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
         } else {
-            RecordBatch::try_new(Arc::clone(&self.schema), arrays)
+            libcudf_rs::record_batch_with_schema(arrays, &self.schema)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
         }
-        .map_err(|err| {
-            DataFusionError::ArrowError(
-                Box::new(err),
-                Some("Error projecting CuDF RecordBatch".to_string()),
-            )
-        })
     }
 }
 

--- a/libcudf-datafusion/src/physical/sort.rs
+++ b/libcudf-datafusion/src/physical/sort.rs
@@ -1,5 +1,6 @@
 use crate::errors::cudf_to_df;
 use arrow::array::RecordBatch;
+use arrow_schema::SchemaRef;
 use datafusion::common::Statistics;
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -71,9 +72,11 @@ impl ExecutionPlan for CuDFSortExec {
             execute_stream(Arc::clone(self.inner.input()), context)?
         };
 
+        let schema = self.schema();
         let ordered_stream = if let Some(limit) = self.fetch() {
             CuDFTopKStream {
                 input,
+                schema,
                 limit,
                 ordering: self.inner.expr().clone(),
                 result: None,
@@ -83,6 +86,7 @@ impl ExecutionPlan for CuDFSortExec {
         } else {
             CuDFSortStream {
                 input,
+                schema,
                 ordering: self.inner.expr().clone(),
                 views: vec![],
                 finished: false,
@@ -109,6 +113,7 @@ impl ExecutionPlan for CuDFSortExec {
 
 struct CuDFSortStream {
     input: SendableRecordBatchStream,
+    schema: SchemaRef,
     ordering: LexOrdering,
     views: Vec<CuDFTableView>,
     finished: bool,
@@ -143,9 +148,12 @@ impl Stream for CuDFSortStream {
                 let (key_columns, sort_orders) = extract_sort_params(&self.ordering);
                 let sorted = sort(&table_view, &key_columns, &sort_orders).map_err(cudf_to_df)?;
 
-                let result = sorted.into_view().to_record_batch().map_err(cudf_to_df);
+                let result = sorted
+                    .into_view()
+                    .to_record_batch_with_schema(&self.schema)
+                    .map_err(cudf_to_df)?;
 
-                Poll::Ready(Some(result))
+                Poll::Ready(Some(Ok(result)))
             }
         }
     }
@@ -162,6 +170,7 @@ impl Stream for CuDFSortStream {
 /// This reduces memory usage and improves performance for large inputs.
 struct CuDFTopKStream {
     input: SendableRecordBatchStream,
+    schema: SchemaRef,
     ordering: LexOrdering,
     limit: usize,
     result: Option<CuDFTableView>,
@@ -232,7 +241,7 @@ impl Stream for CuDFTopKStream {
 
                 let batch = sorted_result
                     .into_view()
-                    .to_record_batch()
+                    .to_record_batch_with_schema(&self.schema)
                     .map_err(cudf_to_df)?;
                 Poll::Ready(Some(Ok(batch)))
             }

--- a/libcudf-datafusion/src/test_utils/mod.rs
+++ b/libcudf-datafusion/src/test_utils/mod.rs
@@ -1,5 +1,7 @@
 pub mod insta;
+#[cfg(test)]
 mod session_context;
 pub mod tpch;
 
+#[cfg(test)]
 pub(crate) use session_context::{check_query_results, sort_batches, TestFramework};

--- a/libcudf-datafusion/tests/tpch_correctness.rs
+++ b/libcudf-datafusion/tests/tpch_correctness.rs
@@ -23,55 +23,47 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_2() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(2)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_3() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(3)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_4() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(4)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_5() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(5)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_6() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(6)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_7() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(7)).await
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "wrong results: mkt_share returns 0 on GPU instead of correct values; likely a CASE expression bug"]
     async fn test_tpch_8() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(8)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_9() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(9)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_10() -> Result<(), Box<dyn Error>> {
         let sql = get_test_tpch_query(10);
         // There is a chance that this query returns non-deterministic results if two entries

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -54,10 +54,9 @@ impl CuDFColumnView {
         self.inner
     }
 
-    /// Create a view with a different Arrow `DataType` label, sharing the same GPU memory.
-    ///
-    /// The caller must ensure the raw GPU values are correct for the new type.
-    /// Safe to use when the view is only unloaded to host, not chained into further GPU arithmetic.
+    /// Relabel this view's Arrow `DataType` without touching GPU memory.
+    /// Used by [`record_batch_with_schema`](crate::record_batch_with_schema) to
+    /// reconcile cuDF's max-precision decimals with declared schema types.
     pub fn with_data_type(self, dt: DataType) -> Self {
         Self {
             _ref: self._ref,

--- a/src/table_view.rs
+++ b/src/table_view.rs
@@ -201,8 +201,10 @@ impl CuDFTableView {
         Ok(RecordBatch::try_new(Arc::new(self.schema()?), columns)?)
     }
 
-    /// Like `to_record_batch`, but attaches `schema` to relabel column names and
-    /// reconcile any type precision differences.
+    /// Wrap GPU columns in a `RecordBatch` whose types match `schema`.
+    ///
+    /// Delegates to [`record_batch_with_schema`]. Use this when the columns
+    /// are still in a `CuDFTableView`.
     pub fn to_record_batch_with_schema(
         &self,
         schema: &SchemaRef,
@@ -217,17 +219,9 @@ impl CuDFTableView {
             )));
         }
         let columns: Vec<ArrayRef> = (0..self.num_columns())
-            .zip(schema.fields())
-            .map(|(i, field)| {
-                let col = self.column(i as i32);
-                if col.data_type() != field.data_type() {
-                    Arc::new(col.with_data_type(field.data_type().clone())) as _
-                } else {
-                    Arc::new(col) as _
-                }
-            })
+            .map(|i| Arc::new(self.column(i as i32)) as _)
             .collect();
-        Ok(RecordBatch::try_new(Arc::clone(schema), columns)?)
+        record_batch_with_schema(columns, schema).map_err(CuDFError::ArrowError)
     }
 
     /// Create a table view from a RecordBatch containing CuDF arrays (GPU)
@@ -251,6 +245,32 @@ impl CuDFTableView {
 
         Self::from_column_views(column_views)
     }
+}
+
+/// Build a `RecordBatch`, relabeling any `CuDFColumnView` whose type differs from
+/// the corresponding `schema` field.
+///
+/// cuDF normalises decimal precision to the storage maximum (e.g. 38 for Decimal128).
+/// This function restores the declared precision so `RecordBatch::try_new` accepts it.
+/// All GPU `RecordBatch` creation should go through this function instead of calling
+/// `RecordBatch::try_new` directly.
+pub fn record_batch_with_schema(
+    columns: Vec<ArrayRef>,
+    schema: &SchemaRef,
+) -> Result<RecordBatch, ArrowError> {
+    let relabeled: Vec<ArrayRef> = columns
+        .into_iter()
+        .zip(schema.fields())
+        .map(|(col, field)| {
+            if col.data_type() != field.data_type() {
+                if let Some(v) = col.as_any().downcast_ref::<CuDFColumnView>() {
+                    return Arc::new(v.clone().with_data_type(field.data_type().clone())) as _;
+                }
+            }
+            col
+        })
+        .collect();
+    RecordBatch::try_new(Arc::clone(schema), relabeled)
 }
 
 impl Clone for CuDFTableView {


### PR DESCRIPTION
fix decimal point conversion.

we cannot just do it at boundaries because there are plenty of stale schemas we run into throughout planning as DFs ype system carries precision everywhere while cudf just uses Decimal128(38.2) 

Instead of converting at boundaries, which cause stale schemas to be error prone, dont change the precision at the boundaries  and let the oringal precision flo throgh, cudf will always use Decimal128(38,2) and just apply the saved schema when creating record batches (this is very cheap as its just relableing how data is interpreted)