### PR TITLE
1fix decimal division truncating to 0

### DIFF
--- a/libcudf-datafusion/src/expr/binary.rs
+++ b/libcudf-datafusion/src/expr/binary.rs
@@ -1,4 +1,5 @@
 use crate::errors::cudf_to_df;
+use crate::expr::decimal::{decimal_div, is_decimal_division};
 use crate::expr::{columnar_value_to_cudf, cudf_to_columnar_value, expr_to_cudf_expr};
 use arrow::array::RecordBatch;
 use arrow_schema::{DataType, FieldRef, Schema};
@@ -77,10 +78,20 @@ impl PhysicalExpr for CuDFBinaryExpr {
             _ => expected.clone(),
         };
 
-        let lhs = columnar_value_to_cudf(self.left.evaluate(batch)?)?;
-        let rhs = columnar_value_to_cudf(self.right.evaluate(batch)?)?;
+        let lhs_value = self.left.evaluate(batch)?;
+        let rhs_value = self.right.evaluate(batch)?;
+        let lhs_type = lhs_value.data_type();
+        let rhs_type = rhs_value.data_type();
+        let lhs = columnar_value_to_cudf(lhs_value)?;
+        let rhs = columnar_value_to_cudf(rhs_value)?;
 
-        let result = cudf_binary_op(lhs, rhs, self.op, &cudf_output_type).map_err(cudf_to_df)?;
+        let result = if self.op == CuDFBinaryOp::Div
+            && is_decimal_division(&expected, &lhs_type, &rhs_type)
+        {
+            decimal_div(lhs, rhs, &lhs_type, &rhs_type, &cudf_output_type)?
+        } else {
+            cudf_binary_op(lhs, rhs, self.op, &cudf_output_type).map_err(cudf_to_df)?
+        };
         Ok(cudf_to_columnar_value(result))
     }
 
@@ -213,6 +224,38 @@ mod tests {
         ");
 
         // Verify against host execution
+        let host_result = tf.execute(host_sql).await?;
+        assert_eq!(host_result.pretty_print, result.pretty_print);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_decimal_division_fractional_result() -> Result<(), Box<dyn std::error::Error>> {
+        let tf = TestFramework::new().await;
+
+        tf.execute(
+            r#"CREATE TABLE ratios (num DECIMAL(10, 2), den DECIMAL(10, 2)) AS VALUES
+                (3.00, 100.00),
+                (42.00, 10.00)"#,
+        )
+        .await?;
+
+        let host_sql = "SELECT num / den as ratio FROM ratios ORDER BY ratio";
+        let result = tf
+            .execute(&format!("SET cudf.enable=true; {host_sql}"))
+            .await?;
+
+        assert_contains!(result.plan, "CuDFProjectionExec");
+        assert_snapshot!(result.pretty_print, @r"
+        +----------+
+        | ratio    |
+        +----------+
+        | 0.030000 |
+        | 4.200000 |
+        +----------+
+        ");
+
         let host_result = tf.execute(host_sql).await?;
         assert_eq!(host_result.pretty_print, result.pretty_print);
 

--- a/libcudf-datafusion/src/expr/decimal.rs
+++ b/libcudf-datafusion/src/expr/decimal.rs
@@ -1,0 +1,111 @@
+use crate::errors::cudf_to_df;
+use arrow::array::Scalar;
+use arrow_schema::{
+    DataType, DECIMAL128_MAX_PRECISION, DECIMAL128_MAX_SCALE, DECIMAL32_MAX_PRECISION,
+    DECIMAL32_MAX_SCALE, DECIMAL64_MAX_PRECISION, DECIMAL64_MAX_SCALE,
+};
+use datafusion::common::{exec_err, DataFusionError};
+use libcudf_rs::{cudf_binary_op, CuDFBinaryOp, CuDFColumnViewOrScalar, CuDFScalar};
+
+pub(super) fn is_decimal_division(
+    output_type: &DataType,
+    lhs_type: &DataType,
+    rhs_type: &DataType,
+) -> bool {
+    decimal_parts(output_type).is_some()
+        && decimal_parts(lhs_type).is_some()
+        && decimal_parts(rhs_type).is_some()
+}
+
+pub(super) fn decimal_div(
+    lhs: CuDFColumnViewOrScalar,
+    rhs: CuDFColumnViewOrScalar,
+    lhs_type: &DataType,
+    rhs_type: &DataType,
+    output_type: &DataType,
+) -> Result<CuDFColumnViewOrScalar, DataFusionError> {
+    let (_, lhs_scale) = decimal_parts(lhs_type).expect("checked by caller");
+    let (_, rhs_scale) = decimal_parts(rhs_type).expect("checked by caller");
+    let (_, output_scale) = decimal_parts(output_type).expect("checked by caller");
+
+    // DataFusion scales the stored numerator before decimal division. cuDF's
+    // fixed-point Div divides the stored integers directly, so rescale first.
+    // Example: 3.00 / 100.00 with output scale 6 is stored as
+    // (300 * 10^6) / 10000 = 30000, which represents 0.030000.
+    let scale_delta = i16::from(output_scale) - i16::from(lhs_scale) + i16::from(rhs_scale);
+
+    let (lhs, rhs) = if scale_delta >= 0 {
+        let target_scale = checked_scale(i16::from(lhs_scale) + scale_delta)?;
+        (rescale_decimal(lhs, lhs_type, target_scale)?, rhs)
+    } else {
+        let target_scale = checked_scale(i16::from(rhs_scale) - scale_delta)?;
+        (lhs, rescale_decimal(rhs, rhs_type, target_scale)?)
+    };
+
+    cudf_binary_op(lhs, rhs, CuDFBinaryOp::Div, output_type).map_err(cudf_to_df)
+}
+
+fn rescale_decimal(
+    value: CuDFColumnViewOrScalar,
+    data_type: &DataType,
+    target_scale: i8,
+) -> Result<CuDFColumnViewOrScalar, DataFusionError> {
+    let (_, current_scale) = decimal_parts(data_type).expect("checked by caller");
+    if target_scale == current_scale {
+        return Ok(value);
+    }
+
+    let target_type = decimal_type_with_scale(data_type, target_scale)?;
+    match value {
+        CuDFColumnViewOrScalar::ColumnView(view) => Ok(libcudf_rs::cast(&view, &target_type)
+            .map_err(cudf_to_df)?
+            .into_view()
+            .into()),
+        CuDFColumnViewOrScalar::Scalar(scalar) => {
+            let array = scalar.to_arrow_host().map_err(cudf_to_df)?;
+            let casted = arrow::compute::cast(array.as_ref(), &target_type)
+                .map_err(|err| DataFusionError::ArrowError(Box::new(err), None))?;
+            Ok(CuDFScalar::from_arrow_host(Scalar::new(casted))
+                .map_err(cudf_to_df)?
+                .into())
+        }
+    }
+}
+
+fn decimal_parts(data_type: &DataType) -> Option<(u8, i8)> {
+    match data_type {
+        DataType::Decimal32(precision, scale)
+        | DataType::Decimal64(precision, scale)
+        | DataType::Decimal128(precision, scale) => Some((*precision, *scale)),
+        _ => None,
+    }
+}
+
+fn decimal_type_with_scale(data_type: &DataType, scale: i8) -> Result<DataType, DataFusionError> {
+    let data_type = match data_type {
+        DataType::Decimal32(_, _)
+            if (-DECIMAL32_MAX_SCALE..=DECIMAL32_MAX_SCALE).contains(&scale) =>
+        {
+            DataType::Decimal32(DECIMAL32_MAX_PRECISION, scale)
+        }
+        DataType::Decimal64(_, _)
+            if (-DECIMAL64_MAX_SCALE..=DECIMAL64_MAX_SCALE).contains(&scale) =>
+        {
+            DataType::Decimal64(DECIMAL64_MAX_PRECISION, scale)
+        }
+        DataType::Decimal128(_, _)
+            if (-DECIMAL128_MAX_SCALE..=DECIMAL128_MAX_SCALE).contains(&scale) =>
+        {
+            DataType::Decimal128(DECIMAL128_MAX_PRECISION, scale)
+        }
+        _ => {
+            return exec_err!("Cannot rescale decimal operand of type {data_type} to scale {scale}")
+        }
+    };
+    Ok(data_type)
+}
+
+fn checked_scale(scale: i16) -> Result<i8, DataFusionError> {
+    i8::try_from(scale)
+        .map_err(|_| DataFusionError::Execution(format!("Decimal scale {scale} is out of range")))
+}

--- a/libcudf-datafusion/src/expr/mod.rs
+++ b/libcudf-datafusion/src/expr/mod.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 mod binary;
 mod column;
+mod decimal;
 mod literal;
 
 pub(crate) fn columnar_value_to_cudf(

--- a/libcudf-datafusion/tests/tpch_correctness.rs
+++ b/libcudf-datafusion/tests/tpch_correctness.rs
@@ -53,7 +53,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "wrong results: mkt_share returns 0 on GPU instead of correct values; likely a CASE expression bug"]
     async fn test_tpch_8() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(8)).await
     }
@@ -75,73 +74,61 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_11() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(11)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_12() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(12)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_13() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(13)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_14() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(14)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_15() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(15)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_16() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(16)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_17() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(17)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_18() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(18)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_19() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(19)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_20() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(20)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_21() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(21)).await
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_tpch_22() -> Result<(), Box<dyn Error>> {
         test_tpch_query(get_test_tpch_query(22)).await
     }


### PR DESCRIPTION
Unignore TPCH queries and fix Q8 to have correct resutls.

Q8 was fialing because DF and cudf used didferent semantics / scaling for decimal division. Thus, handle cudf division by rescaling operands to match DF.