### PR TITLE
[codex] Redesign group-by aggregation API

### DIFF
--- a/libcudf-datafusion/src/physical/aggregate/op/avg.rs
+++ b/libcudf-datafusion/src/physical/aggregate/op/avg.rs
@@ -15,8 +15,7 @@ use datafusion_expr::AggregateUDF;
 use datafusion_physical_plan::aggregates::AggregateMode;
 use datafusion_physical_plan::PhysicalExpr;
 use libcudf_rs::{
-    AggregationOp, AggregationRequest, CuDFBinaryOp, CuDFColumn, CuDFColumnView,
-    CuDFColumnViewOrScalar,
+    Aggregation, CuDFBinaryOp, CuDFColumn, CuDFColumnView, CuDFColumnViewOrScalar, GroupByRequest,
 };
 use std::sync::Arc;
 
@@ -88,16 +87,14 @@ impl CuDFAggregationOp for CuDFAvg {
         }))
     }
 
-    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>> {
         if args.len() != 1 {
             return exec_err!("AVG expects 1 argument, got {}", args.len());
         }
 
-        let mut request = AggregationRequest::from_column_view(args[0].clone());
-        request.add(AggregationOp::COUNT.group_by());
-        request.add(AggregationOp::SUM.group_by());
-
-        Ok(vec![request])
+        Ok(vec![GroupByRequest::new(args[0].clone())
+            .with(Aggregation::Count)
+            .with(Aggregation::Sum)])
     }
 
     fn normalize_partial_state(&self, mut cols: Vec<CuDFColumn>) -> Result<Vec<CuDFColumn>> {
@@ -109,7 +106,7 @@ impl CuDFAggregationOp for CuDFAvg {
         Ok(vec![casted_count, sum])
     }
 
-    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>> {
         if state_cols.len() != 2 {
             return exec_err!(
                 "AVG merge expects 2 state columns, got {}",
@@ -117,13 +114,10 @@ impl CuDFAggregationOp for CuDFAvg {
             );
         }
 
-        let mut count_request = AggregationRequest::from_column_view(state_cols[0].clone());
-        count_request.add(AggregationOp::SUM.group_by());
-
-        let mut sum_request = AggregationRequest::from_column_view(state_cols[1].clone());
-        sum_request.add(AggregationOp::SUM.group_by());
-
-        Ok(vec![count_request, sum_request])
+        Ok(vec![
+            GroupByRequest::new(state_cols[0].clone()).with(Aggregation::Sum),
+            GroupByRequest::new(state_cols[1].clone()).with(Aggregation::Sum),
+        ])
     }
 
     fn finalize(

--- a/libcudf-datafusion/src/physical/aggregate/op/count.rs
+++ b/libcudf-datafusion/src/physical/aggregate/op/count.rs
@@ -7,7 +7,7 @@ use datafusion::error::Result;
 use datafusion::functions_aggregate::count::Count;
 use datafusion_expr::AggregateUDF;
 use datafusion_physical_plan::PhysicalExpr;
-use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumn, CuDFColumnView};
+use libcudf_rs::{Aggregation, CuDFColumn, CuDFColumnView, GroupByRequest};
 use std::sync::Arc;
 
 pub fn count() -> Arc<AggregateUDF> {
@@ -45,22 +45,20 @@ impl CuDFAggregationOp for CuDFCount {
             .unwrap_or_default())
     }
 
-    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>> {
         if args.len() != 1 {
             return exec_err!("COUNT expects 1 argument, got {}", args.len());
         }
 
-        let mut request = AggregationRequest::from_column_view(args[0].clone());
-        let op = if self.count_nulls {
-            AggregationOp::COUNT_ALL
+        let aggregation = if self.count_nulls {
+            Aggregation::CountAll
         } else {
-            AggregationOp::COUNT
+            Aggregation::Count
         };
-        request.add(op.group_by());
-        Ok(vec![request])
+        Ok(vec![GroupByRequest::new(args[0].clone()).with(aggregation)])
     }
 
-    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>> {
         if state_cols.len() != 1 {
             return exec_err!(
                 "COUNT merge expects 1 state column, got {}",
@@ -68,9 +66,9 @@ impl CuDFAggregationOp for CuDFCount {
             );
         }
 
-        let mut request = AggregationRequest::from_column_view(state_cols[0].clone());
-        request.add(AggregationOp::SUM.group_by());
-        Ok(vec![request])
+        Ok(vec![
+            GroupByRequest::new(state_cols[0].clone()).with(Aggregation::Sum)
+        ])
     }
 
     fn normalize_partial_state(&self, mut cols: Vec<CuDFColumn>) -> Result<Vec<CuDFColumn>> {

--- a/libcudf-datafusion/src/physical/aggregate/op/max.rs
+++ b/libcudf-datafusion/src/physical/aggregate/op/max.rs
@@ -4,7 +4,7 @@ use datafusion::common::exec_err;
 use datafusion::error::Result;
 use datafusion::functions_aggregate::min_max::Max;
 use datafusion_expr::AggregateUDF;
-use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumnView};
+use libcudf_rs::{Aggregation, CuDFColumnView, GroupByRequest};
 use std::sync::Arc;
 
 pub fn max() -> Arc<AggregateUDF> {
@@ -20,24 +20,24 @@ impl CuDFAggregationOp for CuDFMax {
         1
     }
 
-    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>> {
         if args.len() != 1 {
             return exec_err!("MAX expects 1 argument, got {}", args.len());
         }
 
-        let mut request = AggregationRequest::from_column_view(args[0].clone());
-        request.add(AggregationOp::MAX.group_by());
-        Ok(vec![request])
+        Ok(vec![
+            GroupByRequest::new(args[0].clone()).with(Aggregation::Max)
+        ])
     }
 
-    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>> {
         if state_cols.len() != 1 {
             return exec_err!("MAX merge expects 1 state column, got {}", state_cols.len());
         }
 
-        let mut request = AggregationRequest::from_column_view(state_cols[0].clone());
-        request.add(AggregationOp::MAX.group_by());
-        Ok(vec![request])
+        Ok(vec![
+            GroupByRequest::new(state_cols[0].clone()).with(Aggregation::Max)
+        ])
     }
 
     fn finalize(

--- a/libcudf-datafusion/src/physical/aggregate/op/min.rs
+++ b/libcudf-datafusion/src/physical/aggregate/op/min.rs
@@ -4,7 +4,7 @@ use datafusion::common::exec_err;
 use datafusion::error::Result;
 use datafusion::functions_aggregate::min_max::Min;
 use datafusion_expr::AggregateUDF;
-use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumnView};
+use libcudf_rs::{Aggregation, CuDFColumnView, GroupByRequest};
 use std::sync::Arc;
 
 pub fn min() -> Arc<AggregateUDF> {
@@ -20,24 +20,24 @@ impl CuDFAggregationOp for CuDFMin {
         1
     }
 
-    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>> {
         if args.len() != 1 {
             return exec_err!("MIN expects 1 argument, got {}", args.len());
         }
 
-        let mut request = AggregationRequest::from_column_view(args[0].clone());
-        request.add(AggregationOp::MIN.group_by());
-        Ok(vec![request])
+        Ok(vec![
+            GroupByRequest::new(args[0].clone()).with(Aggregation::Min)
+        ])
     }
 
-    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>> {
         if state_cols.len() != 1 {
             return exec_err!("MIN merge expects 1 state column, got {}", state_cols.len());
         }
 
-        let mut request = AggregationRequest::from_column_view(state_cols[0].clone());
-        request.add(AggregationOp::MIN.group_by());
-        Ok(vec![request])
+        Ok(vec![
+            GroupByRequest::new(state_cols[0].clone()).with(Aggregation::Min)
+        ])
     }
 
     fn finalize(

--- a/libcudf-datafusion/src/physical/aggregate/op/mod.rs
+++ b/libcudf-datafusion/src/physical/aggregate/op/mod.rs
@@ -4,7 +4,7 @@ use arrow_schema::SchemaRef;
 use datafusion::error::Result;
 use datafusion_physical_plan::aggregates::AggregateMode;
 use datafusion_physical_plan::PhysicalExpr;
-use libcudf_rs::{AggregationRequest, CuDFColumn, CuDFColumnView};
+use libcudf_rs::{CuDFColumn, CuDFColumnView, GroupByRequest};
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -70,7 +70,7 @@ pub trait CuDFAggregationOp: Debug + Send + Sync {
     }
 
     /// Build cuDF aggregation requests for raw input data.
-    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>>;
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>>;
 
     /// Normalize state columns produced by `partial_requests` so their types are
     /// compatible with `merge_requests` for subsequent merge cycles, and match the
@@ -84,7 +84,7 @@ pub trait CuDFAggregationOp: Debug + Send + Sync {
     }
 
     /// Build cuDF aggregation requests that combine intermediate state columns.
-    fn merge_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>>;
+    fn merge_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>>;
 
     /// Convert merged state columns into the final output column.
     fn finalize(&self, args: &[CuDFColumnView], output_type: &DataType) -> Result<CuDFColumnView>;

--- a/libcudf-datafusion/src/physical/aggregate/op/sum.rs
+++ b/libcudf-datafusion/src/physical/aggregate/op/sum.rs
@@ -6,7 +6,7 @@ use datafusion::error::Result;
 use datafusion::functions_aggregate::sum::Sum;
 use datafusion_expr::AggregateUDF;
 use datafusion_physical_plan::PhysicalExpr;
-use libcudf_rs::{AggregationOp, AggregationRequest, CuDFColumnView};
+use libcudf_rs::{Aggregation, CuDFColumnView, GroupByRequest};
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -33,17 +33,17 @@ impl CuDFAggregationOp for CuDFSum {
             .unwrap_or_default())
     }
 
-    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn partial_requests(&self, args: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>> {
         if args.len() != 1 {
             return exec_err!("SUM expects 1 argument, received: {}", args.len());
         }
 
-        let mut request = AggregationRequest::from_column_view(args[0].clone());
-        request.add(AggregationOp::SUM.group_by());
-        Ok(vec![request])
+        Ok(vec![
+            GroupByRequest::new(args[0].clone()).with(Aggregation::Sum)
+        ])
     }
 
-    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<AggregationRequest>> {
+    fn merge_requests(&self, state_cols: &[CuDFColumnView]) -> Result<Vec<GroupByRequest>> {
         if state_cols.len() != 1 {
             return exec_err!(
                 "SUM merge expects 1 state column, received: {}",
@@ -51,9 +51,9 @@ impl CuDFAggregationOp for CuDFSum {
             );
         }
 
-        let mut request = AggregationRequest::from_column_view(state_cols[0].clone());
-        request.add(AggregationOp::SUM.group_by());
-        Ok(vec![request])
+        Ok(vec![
+            GroupByRequest::new(state_cols[0].clone()).with(Aggregation::Sum)
+        ])
     }
 
     fn finalize(

--- a/libcudf-datafusion/src/physical/aggregate/stream.rs
+++ b/libcudf-datafusion/src/physical/aggregate/stream.rs
@@ -16,7 +16,7 @@ use datafusion_physical_plan::aggregates::{evaluate_group_by, evaluate_many, Agg
 use datafusion_physical_plan::PhysicalExpr;
 use futures::{ready, StreamExt};
 use libcudf_rs::{
-    record_batch_with_schema, CuDFColumn, CuDFColumnView, CuDFGroupBy, CuDFTable, CuDFTableView,
+    record_batch_with_schema, CuDFColumn, CuDFColumnView, CuDFTable, CuDFTableView, GroupByRequest,
 };
 use std::pin::Pin;
 use std::sync::Arc;
@@ -186,11 +186,10 @@ impl CuDFAggregateStream {
         let evaluated_args = self.evaluate_batch_arguments(&chunk)?;
         let requests = self.build_batch_requests(evaluated_args)?;
 
-        let (chunk_keys, chunk_results) = {
+        let (chunk_keys, mut chunk_state_columns) = {
             let _timer = self.group_by_metrics.aggregation_time.timer();
-            execute_cudf(group_by.aggregate(requests))?
+            execute_cudf(group_by.aggregate(requests))?.into_flat_columns()
         };
-        let mut chunk_state_columns = chunk_results.into_iter().flatten().collect();
 
         // Normalize partial state column types so they are compatible with merge_requests.
         if !matches!(
@@ -226,7 +225,7 @@ impl CuDFAggregateStream {
     fn build_batch_requests(
         &self,
         evaluated_args: Vec<Vec<CuDFColumnView>>,
-    ) -> Result<Vec<libcudf_rs::AggregationRequest>> {
+    ) -> Result<Vec<GroupByRequest>> {
         let mut requests = Vec::new();
 
         let use_merge = matches!(
@@ -294,12 +293,11 @@ impl CuDFAggregateStream {
         }
 
         // Re-aggregate
-        let group_by = CuDFGroupBy::from_table_view(combined_keys.into_view());
-        let (merged_keys, merged_results) = {
+        let group_by = combined_keys.into_view().group_by_all();
+        let (merged_keys, merged_state_columns) = {
             let _timer = self.group_by_metrics.aggregation_time.timer();
-            execute_cudf(group_by.aggregate(requests))?
+            execute_cudf(group_by.aggregate(requests))?.into_flat_columns()
         };
-        let merged_state_columns = merged_results.into_iter().flatten().collect();
 
         self.running = Some(RunningState {
             keys: merged_keys,
@@ -397,7 +395,7 @@ impl CuDFAggregateStream {
 
     /// Evaluate GROUP BY expressions on a batch and wrap the resulting key
     /// columns into a [`CuDFGroupBy`] for GPU aggregation.
-    fn evaluate_batch_groups(&self, batch: &RecordBatch) -> Result<CuDFGroupBy> {
+    fn evaluate_batch_groups(&self, batch: &RecordBatch) -> Result<libcudf_rs::CuDFGroupBy> {
         let _timer = self.group_by_metrics.time_calculating_group_ids.timer();
         let grouping_sets = evaluate_group_by(&self.prepared.group_by, batch)?;
 
@@ -418,7 +416,7 @@ impl CuDFAggregateStream {
 
         let table_view = CuDFTableView::from_column_views(column_views).map_err(cudf_to_df)?;
 
-        Ok(CuDFGroupBy::from_table_view(table_view))
+        Ok(table_view.group_by_all())
     }
 
     /// Evaluate each aggregate function's argument expressions on a batch,

--- a/src/column_view.rs
+++ b/src/column_view.rs
@@ -18,9 +18,10 @@ use std::sync::{Arc, OnceLock};
 /// owning cuDF object alive so the referenced GPU buffers remain valid, and it
 /// implements Arrow's [`Array`] trait for interoperability with Arrow APIs.
 pub struct CuDFColumnView {
-    // Keep backing storage alive so the view remains valid.
-    storage: Option<CuDFViewStorage>,
+    // Non-owning cuDF view. Keep this before `storage` so it drops first.
     inner: UniquePtr<ffi::ColumnView>,
+    // Backing owner for the buffers referenced by `inner`.
+    storage: Option<CuDFViewStorage>,
     dt: DataType,
     null_buf: OnceLock<Option<NullBuffer>>,
     stream_readiness: Option<CuDFStreamDependency>,
@@ -36,8 +37,8 @@ impl CuDFColumnView {
         let dt = cudf_type_to_arrow(&cudf_dtype);
         let dt = dt.unwrap_or(DataType::Null);
         Self {
-            storage,
             inner,
+            storage,
             dt,
             null_buf: OnceLock::new(),
             stream_readiness,
@@ -57,8 +58,8 @@ impl CuDFColumnView {
     /// adjust cuDF's max-precision decimals with declared schema types.
     pub(crate) fn with_data_type(self, dt: DataType) -> Self {
         Self {
-            storage: self.storage,
             inner: self.inner,
+            storage: self.storage,
             dt,
             null_buf: self.null_buf,
             stream_readiness: self.stream_readiness,
@@ -202,8 +203,8 @@ impl Clone for CuDFColumnView {
     fn clone(&self) -> Self {
         let cloned_inner = self.inner.clone();
         Self {
-            storage: self.storage.clone(),
             inner: cloned_inner,
+            storage: self.storage.clone(),
             dt: self.dt.clone(),
             null_buf: self.null_buf.clone(),
             stream_readiness: self.stream_readiness.clone(),

--- a/src/execution_context.rs
+++ b/src/execution_context.rs
@@ -433,10 +433,13 @@ mod tests {
             .execute(crate::CuDFColumn::from_arrow_host(&values))?
             .into_view();
 
-        let group_by = crate::CuDFGroupBy::from_table_view(keys);
-        let mut request = crate::AggregationRequest::from_column_view(values);
-        request.add(crate::AggregationOp::SUM.group_by());
-        let (keys, results) = consumer.execute(group_by.aggregate([request]))?;
+        let group_by = keys.group_by_all();
+        let result =
+            consumer
+                .execute(group_by.aggregate([
+                    crate::GroupByRequest::new(values).with(crate::Aggregation::Sum),
+                ]))?;
+        let (keys, results) = result.into_parts();
         let sums = results
             .into_iter()
             .next()

--- a/src/group_by.rs
+++ b/src/group_by.rs
@@ -1,8 +1,13 @@
-use crate::deferred_operation::deferred;
+use crate::deferred_operation::operation_impl::CuDFOperationImpl;
 use crate::execution_policy;
 use crate::keep_alive::CuDFKeepAlive;
+use crate::stream_readiness::CuDFStreamDependency;
 use crate::table_view::CuDFTableView;
-use crate::{CuDFColumn, CuDFColumnView, CuDFOperation, CuDFTable};
+use crate::{
+    CuDFColumn, CuDFColumnView, CuDFError, CuDFExecutionContext, CuDFOperation, CuDFTable,
+};
+use arrow::array::Array;
+use arrow_schema::ArrowError;
 use cxx::UniquePtr;
 use libcudf_sys::ffi::{
     self, aggregation_request_create, aggregation_requests_create, make_count_aggregation_groupby,
@@ -11,28 +16,29 @@ use libcudf_sys::ffi::{
     make_sum_aggregation_groupby, make_variance_aggregation_groupby,
 };
 use libcudf_sys::{NullPolicy, Sorted};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-/// A group-by operation builder
+/// A reusable cuDF group-by built from key columns.
 ///
-/// Groups rows by key columns and computes aggregations on value columns
-/// for each group. Created with key columns and then used to perform
-/// multiple aggregations.
+/// Create this from a [`CuDFTableView`] and execute one or more grouped
+/// aggregations with [`aggregate`](Self::aggregate).
 #[derive(Clone)]
 pub struct CuDFGroupBy {
     inner: Arc<CuDFGroupByInner>,
 }
 
 struct CuDFGroupByInner {
-    keys: CuDFTableView,
+    // cuDF's groupby is built from `keys`; drop it before the key view/storage.
     inner: UniquePtr<ffi::GroupBy>,
+    // Retain the last aggregate stream until the groupby handle is destroyed.
+    destruction_dependency: Mutex<Option<CuDFStreamDependency>>,
+    keys: CuDFTableView,
 }
 
 impl CuDFGroupBy {
-    /// Create a group-by operation with the specified key columns
+    /// Create a group-by from key columns.
     ///
-    /// The keys determine how rows are grouped. Rows with matching key
-    /// values will be grouped together for aggregation.
+    /// Rows with equal key values are placed in the same group.
     pub fn from_table_view(view: CuDFTableView) -> Self {
         let column_order: &[i32] = &[];
         let null_precedence: &[i32] = &[];
@@ -44,172 +50,272 @@ impl CuDFGroupBy {
             null_precedence,
         );
         Self {
-            inner: Arc::new(CuDFGroupByInner { keys: view, inner }),
+            inner: Arc::new(CuDFGroupByInner {
+                inner,
+                destruction_dependency: Mutex::new(None),
+                keys: view,
+            }),
         }
     }
 
-    /// Create a deferred operation that aggregates the grouped data.
+    /// Create a deferred grouped aggregation.
     ///
-    /// Each request specifies a column to aggregate and the aggregations
-    /// to perform on it. Execution waits for the key table and request columns,
-    /// then returns the unique group keys and aggregation results for each
-    /// group.
-    pub fn aggregate<'a, I>(
-        &'a self,
-        requests: I,
-    ) -> impl CuDFOperation<Output = (CuDFTable, Vec<Vec<CuDFColumn>>)> + 'a
+    /// Each request supplies one value column and one or more aggregations to
+    /// compute for that column.
+    ///
+    /// # Errors
+    ///
+    /// Execution returns an error if there are no requests, a request has no
+    /// aggregations, a value column length does not match the key row count, or
+    /// cuDF cannot compute the grouped result.
+    pub fn aggregate<I>(&self, requests: I) -> GroupByAggregate<'_>
     where
-        I: IntoIterator<Item = AggregationRequest> + 'a,
+        I: IntoIterator<Item = GroupByRequest>,
     {
-        deferred(move |ctx| {
-            let mut launch = execution_policy::launch(ctx)?;
-            launch.wait_table(&self.inner.keys)?;
-            launch.keep_alive(CuDFKeepAlive::GroupBy {
-                _group_by: CuDFGroupBy::clone(self),
-            });
-            let mut requests_inner = aggregation_requests_create();
-            for request in requests {
-                launch.wait_column(&request.view)?;
-                requests_inner.pin_mut().add(request.inner);
-            }
-
-            let mut gby_result =
-                self.inner
-                    .inner
-                    .aggregate(&requests_inner, launch.stream()?, launch.resource())?;
-            let keys = gby_result.pin_mut().release_keys();
-            let dependency = launch.into_stream_dependency()?;
-            let keys = CuDFTable::from_inner(keys).with_stream_readiness(dependency.clone());
-
-            let mut results = Vec::with_capacity(gby_result.len());
-            for i in 0..gby_result.len() {
-                let mut released_result = gby_result.pin_mut().release_result(i);
-                let mut cols = Vec::with_capacity(released_result.len());
-                for j in 0..released_result.len() {
-                    let col = released_result.pin_mut().release(j);
-                    cols.push(
-                        CuDFColumn::from_inner(col).with_stream_readiness(dependency.clone()),
-                    );
-                }
-
-                results.push(cols)
-            }
-            Ok((keys, results))
-        })
-    }
-}
-
-/// A request to aggregate a column in a group-by operation
-///
-/// Specifies a column of values to aggregate and the aggregations to
-/// perform on it. Multiple aggregations can be added to a single request.
-pub struct AggregationRequest {
-    view: CuDFColumnView,
-    inner: UniquePtr<ffi::AggregationRequest>,
-}
-
-impl AggregationRequest {
-    /// Create an aggregation request for a column
-    ///
-    /// The group membership of each value is determined by the corresponding
-    /// row in the keys used to construct the groupby.
-    pub fn from_column_view(view: CuDFColumnView) -> Self {
-        let inner = aggregation_request_create(view.inner());
-        Self { view, inner }
-    }
-
-    /// Add an aggregation to this request
-    ///
-    /// Multiple aggregations can be added to aggregate the same column
-    /// in different ways (e.g., both SUM and COUNT).
-    pub fn add(&mut self, aggregation: GroupByAggregation) {
-        self.inner.add(aggregation.inner);
-    }
-}
-
-/// A groupby aggregation operation specification
-///
-/// Specifies how to aggregate values within each group. Created using
-/// factory methods from `AggregationOp`.
-pub struct GroupByAggregation {
-    inner: UniquePtr<ffi::GroupByAggregation>,
-}
-
-impl GroupByAggregation {
-    /// Create a groupby aggregation from a cuDF aggregation pointer
-    pub fn new(inner: UniquePtr<ffi::GroupByAggregation>) -> Self {
-        Self { inner }
-    }
-}
-
-/// Backwards-compatible alias for groupby aggregations.
-pub type Aggregation = GroupByAggregation;
-
-/// Types of aggregation operations
-///
-/// Specifies the aggregation function to apply to grouped values.
-#[allow(non_camel_case_types)]
-pub enum AggregationOp {
-    /// Sum of values
-    SUM,
-    /// Minimum value
-    MIN,
-    /// Maximum value
-    MAX,
-    /// Arithmetic mean
-    MEAN,
-    /// Count of non-null values
-    COUNT,
-    /// Count of all values, including nulls
-    COUNT_ALL,
-    /// Variance with delta degrees of freedom
-    ///
-    /// - `ddof = 0`: Population std dev
-    /// - `ddof = 1`: Sample std dev
-    VARIANCE { ddof: i32 },
-    /// Standard deviation with delta degrees of freedom
-    ///
-    /// - `ddof = 0`: Population std dev
-    /// - `ddof = 1`: Sample std dev
-    STD { ddof: i32 },
-    /// Count of distinct, non-null values
-    NUNIQUE,
-    /// Median value
-    MEDIAN,
-}
-
-impl AggregationOp {
-    /// Create an aggregation for use in group-by operations
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use libcudf_rs::AggregationOp;
-    ///
-    /// let sum_agg = AggregationOp::SUM.group_by();
-    /// let count_agg = AggregationOp::COUNT.group_by();
-    /// ```
-    pub fn group_by(&self) -> GroupByAggregation {
-        use AggregationOp::*;
-        match self {
-            SUM => GroupByAggregation::new(make_sum_aggregation_groupby()),
-            MIN => GroupByAggregation::new(make_min_aggregation_groupby()),
-            MAX => GroupByAggregation::new(make_max_aggregation_groupby()),
-            MEAN => GroupByAggregation::new(make_mean_aggregation_groupby()),
-            COUNT => {
-                GroupByAggregation::new(make_count_aggregation_groupby(NullPolicy::Exclude as i32))
-            }
-            COUNT_ALL => {
-                GroupByAggregation::new(make_count_aggregation_groupby(NullPolicy::Include as i32))
-            }
-            VARIANCE { ddof } => GroupByAggregation::new(make_variance_aggregation_groupby(*ddof)),
-            STD { ddof } => GroupByAggregation::new(make_std_aggregation_groupby(*ddof)),
-            NUNIQUE => GroupByAggregation::new(make_nunique_aggregation_groupby(
-                NullPolicy::Exclude as i32,
-            )),
-            MEDIAN => GroupByAggregation::new(make_median_aggregation_groupby()),
+        GroupByAggregate {
+            group_by: self,
+            requests: requests.into_iter().collect(),
         }
     }
+}
+
+/// Deferred grouped aggregation.
+///
+/// Created by [`CuDFGroupBy::aggregate`]. Execution waits for the group keys
+/// and all requested value columns, then returns unique group keys and
+/// request-ordered aggregation columns.
+///
+/// # Errors
+///
+/// Execution returns an error if request validation fails or cuDF cannot
+/// compute the grouped result.
+pub struct GroupByAggregate<'a> {
+    group_by: &'a CuDFGroupBy,
+    requests: Vec<GroupByRequest>,
+}
+
+impl CuDFOperation for GroupByAggregate<'_> {
+    type Output = CuDFGroupByResult;
+}
+
+impl CuDFOperationImpl for GroupByAggregate<'_> {
+    fn execute_on_context(
+        self,
+        ctx: &CuDFExecutionContext,
+    ) -> crate::Result<<Self as CuDFOperation>::Output> {
+        validate_group_by_requests(&self.group_by.inner.keys, &self.requests)?;
+
+        let mut launch = execution_policy::launch(ctx)?;
+        launch.wait_table(&self.group_by.inner.keys)?;
+        launch.keep_alive(CuDFKeepAlive::GroupBy {
+            _group_by: CuDFGroupBy::clone(self.group_by),
+        });
+
+        let mut requests_inner = aggregation_requests_create();
+        for request in self.requests {
+            launch.wait_column(&request.values)?;
+            let mut inner = aggregation_request_create(request.values.inner());
+            for aggregation in request.aggregations {
+                inner.pin_mut().add(aggregation.into_ffi());
+            }
+            requests_inner.pin_mut().add(inner);
+        }
+
+        let mut gby_result = self.group_by.inner.inner.aggregate(
+            &requests_inner,
+            launch.stream()?,
+            launch.resource(),
+        )?;
+        let keys = gby_result.pin_mut().release_keys();
+
+        let mut released_columns = Vec::with_capacity(gby_result.len());
+        for i in 0..gby_result.len() {
+            let mut released_result = gby_result.pin_mut().release_result(i);
+            let mut request_columns = Vec::with_capacity(released_result.len());
+            for j in 0..released_result.len() {
+                request_columns.push(released_result.pin_mut().release(j));
+            }
+
+            released_columns.push(request_columns)
+        }
+
+        let groupby_dependency = launch.record_stream_dependency(Vec::new())?;
+        *self
+            .group_by
+            .inner
+            .destruction_dependency
+            .lock()
+            .map_err(|_| invalid_argument("group-by dependency lock poisoned"))? =
+            Some(groupby_dependency);
+
+        let dependency = launch.into_stream_dependency()?;
+        let keys = CuDFTable::from_inner(keys).with_stream_readiness(dependency.clone());
+        let mut columns = Vec::with_capacity(released_columns.len());
+        for released_result in released_columns {
+            let mut request_columns = Vec::with_capacity(released_result.len());
+            for col in released_result {
+                request_columns
+                    .push(CuDFColumn::from_inner(col).with_stream_readiness(dependency.clone()));
+            }
+            columns.push(request_columns);
+        }
+        Ok(CuDFGroupByResult { keys, columns })
+    }
+}
+
+/// Result of a grouped aggregation.
+pub struct CuDFGroupByResult {
+    keys: CuDFTable,
+    columns: Vec<Vec<CuDFColumn>>,
+}
+
+impl CuDFGroupByResult {
+    /// Unique group keys.
+    pub fn keys(&self) -> &CuDFTable {
+        &self.keys
+    }
+
+    /// Aggregation columns grouped by request, then by aggregation order.
+    pub fn columns(&self) -> &[Vec<CuDFColumn>] {
+        &self.columns
+    }
+
+    /// Aggregation columns for one request, in aggregation order.
+    pub fn columns_for_request(&self, request: usize) -> Option<&[CuDFColumn]> {
+        self.columns.get(request).map(Vec::as_slice)
+    }
+
+    /// Return one aggregation column by request index and aggregation index.
+    pub fn column(&self, request: usize, aggregation: usize) -> Option<&CuDFColumn> {
+        self.columns
+            .get(request)
+            .and_then(|columns| columns.get(aggregation))
+    }
+
+    /// Consume this result into its key table and grouped aggregation columns.
+    pub fn into_parts(self) -> (CuDFTable, Vec<Vec<CuDFColumn>>) {
+        (self.keys, self.columns)
+    }
+
+    /// Consume this result into its key table and request-ordered columns.
+    pub fn into_flat_columns(self) -> (CuDFTable, Vec<CuDFColumn>) {
+        let columns = self.columns.into_iter().flatten().collect();
+        (self.keys, columns)
+    }
+}
+
+/// A value column and aggregations for a group-by operation.
+///
+/// Multiple aggregations can be added to compute several results for the same
+/// value column.
+#[derive(Clone)]
+pub struct GroupByRequest {
+    values: CuDFColumnView,
+    aggregations: Vec<Aggregation>,
+}
+
+impl GroupByRequest {
+    /// Create a request for a value column.
+    ///
+    /// Each value is grouped by the key row at the same index.
+    pub fn new(values: CuDFColumnView) -> Self {
+        Self {
+            values,
+            aggregations: Vec::new(),
+        }
+    }
+
+    /// Add an aggregation and return the request.
+    ///
+    /// Use this for builder-style request construction.
+    #[must_use]
+    pub fn with(mut self, aggregation: Aggregation) -> Self {
+        self.aggregations.push(aggregation);
+        self
+    }
+}
+
+/// Aggregation to apply to grouped values.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Aggregation {
+    /// Sum.
+    Sum,
+    /// Minimum.
+    Min,
+    /// Maximum.
+    Max,
+    /// Mean.
+    Mean,
+    /// Count non-null values.
+    Count,
+    /// Count all values, including nulls.
+    CountAll,
+    /// Variance with delta degrees of freedom.
+    ///
+    /// - `ddof = 0`: Population variance
+    /// - `ddof = 1`: Sample variance
+    Variance { ddof: i32 },
+    /// Standard deviation with delta degrees of freedom.
+    ///
+    /// - `ddof = 0`: Population std dev
+    /// - `ddof = 1`: Sample std dev
+    Std { ddof: i32 },
+    /// Count distinct non-null values.
+    NUnique,
+    /// Count distinct values, including nulls.
+    NUniqueAll,
+    /// Median.
+    Median,
+}
+
+impl Aggregation {
+    fn into_ffi(self) -> UniquePtr<ffi::GroupByAggregation> {
+        use Aggregation::*;
+        match self {
+            Sum => make_sum_aggregation_groupby(),
+            Min => make_min_aggregation_groupby(),
+            Max => make_max_aggregation_groupby(),
+            Mean => make_mean_aggregation_groupby(),
+            Count => make_count_aggregation_groupby(NullPolicy::Exclude as i32),
+            CountAll => make_count_aggregation_groupby(NullPolicy::Include as i32),
+            Variance { ddof } => make_variance_aggregation_groupby(ddof),
+            Std { ddof } => make_std_aggregation_groupby(ddof),
+            NUnique => make_nunique_aggregation_groupby(NullPolicy::Exclude as i32),
+            NUniqueAll => make_nunique_aggregation_groupby(NullPolicy::Include as i32),
+            Median => make_median_aggregation_groupby(),
+        }
+    }
+}
+
+fn validate_group_by_requests(
+    keys: &CuDFTableView,
+    requests: &[GroupByRequest],
+) -> crate::Result<()> {
+    if requests.is_empty() {
+        return Err(invalid_argument(
+            "group-by aggregate requires at least one request",
+        ));
+    }
+
+    for request in requests {
+        if request.aggregations.is_empty() {
+            return Err(invalid_argument(
+                "group-by request must contain at least one aggregation",
+            ));
+        }
+        if request.values.len() != keys.num_rows() {
+            return Err(invalid_argument(format!(
+                "group-by request value length {} does not match key row count {}",
+                request.values.len(),
+                keys.num_rows()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn invalid_argument(message: impl Into<String>) -> CuDFError {
+    CuDFError::ArrowError(ArrowError::InvalidArgumentError(message.into()))
 }
 
 #[cfg(test)]
@@ -225,7 +331,7 @@ mod tests {
     fn test_sum_integers() -> std::result::Result<(), Box<dyn std::error::Error>> {
         // SUM([1, 2, 3, 4, 5]) = 15
         let values = Int32Array::from(vec![1, 2, 3, 4, 5]);
-        let result = run_single_group_agg::<Int64Array>(&values, AggregationOp::SUM)?;
+        let result = run_single_group_agg::<Int64Array>(&values, Aggregation::Sum)?;
         assert_eq!(result.value(0), 15);
         Ok(())
     }
@@ -234,7 +340,7 @@ mod tests {
     fn test_sum_with_nulls() -> std::result::Result<(), Box<dyn std::error::Error>> {
         // SUM([1, NULL, 3, NULL, 5]) = 9
         let values = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
-        let result = run_single_group_agg::<Int64Array>(&values, AggregationOp::SUM)?;
+        let result = run_single_group_agg::<Int64Array>(&values, Aggregation::Sum)?;
         assert_eq!(result.value(0), 9);
         Ok(())
     }
@@ -243,7 +349,7 @@ mod tests {
     fn test_min() -> std::result::Result<(), Box<dyn std::error::Error>> {
         // MIN([5, 2, 8, 1, 9]) = 1
         let values = Int32Array::from(vec![5, 2, 8, 1, 9]);
-        let result = run_single_group_agg::<Int32Array>(&values, AggregationOp::MIN)?;
+        let result = run_single_group_agg::<Int32Array>(&values, Aggregation::Min)?;
         assert_eq!(result.value(0), 1);
         Ok(())
     }
@@ -252,7 +358,7 @@ mod tests {
     fn test_max() -> std::result::Result<(), Box<dyn std::error::Error>> {
         // MAX([5, 2, 8, 1, 9]) = 9
         let values = Int32Array::from(vec![5, 2, 8, 1, 9]);
-        let result = run_single_group_agg::<Int32Array>(&values, AggregationOp::MAX)?;
+        let result = run_single_group_agg::<Int32Array>(&values, Aggregation::Max)?;
         assert_eq!(result.value(0), 9);
         Ok(())
     }
@@ -261,7 +367,7 @@ mod tests {
     fn test_mean() -> std::result::Result<(), Box<dyn std::error::Error>> {
         // MEAN([10, 20, 30, 40, 50]) = 30
         let values = Float64Array::from(vec![10.0, 20.0, 30.0, 40.0, 50.0]);
-        let result = run_single_group_agg::<Float64Array>(&values, AggregationOp::MEAN)?;
+        let result = run_single_group_agg::<Float64Array>(&values, Aggregation::Mean)?;
         assert!((result.value(0) - 30.0).abs() < 1e-6);
         Ok(())
     }
@@ -270,7 +376,7 @@ mod tests {
     fn test_count() -> std::result::Result<(), Box<dyn std::error::Error>> {
         // COUNT([1, 2, 3, 4, 5]) = 5
         let values = Int32Array::from(vec![1, 2, 3, 4, 5]);
-        let result = run_single_group_agg::<Int32Array>(&values, AggregationOp::COUNT)?;
+        let result = run_single_group_agg::<Int32Array>(&values, Aggregation::Count)?;
         assert_eq!(result.value(0), 5);
         Ok(())
     }
@@ -279,7 +385,7 @@ mod tests {
     fn test_count_excludes_nulls() -> std::result::Result<(), Box<dyn std::error::Error>> {
         // COUNT([1, NULL, 3, NULL, 5]) = 3
         let values = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
-        let result = run_single_group_agg::<Int32Array>(&values, AggregationOp::COUNT)?;
+        let result = run_single_group_agg::<Int32Array>(&values, Aggregation::Count)?;
         assert_eq!(result.value(0), 3);
         Ok(())
     }
@@ -289,7 +395,7 @@ mod tests {
         // VARIANCE([1, 2, 3, 4, 5]) with ddof=1 = 2.5
         let values = Float64Array::from(vec![1.0, 2.0, 3.0, 4.0, 5.0]);
         let result =
-            run_single_group_agg::<Float64Array>(&values, AggregationOp::VARIANCE { ddof: 1 })?;
+            run_single_group_agg::<Float64Array>(&values, Aggregation::Variance { ddof: 1 })?;
         assert!((result.value(0) - 2.5).abs() < 1e-6);
         Ok(())
     }
@@ -298,7 +404,7 @@ mod tests {
     fn test_std_sample() -> std::result::Result<(), Box<dyn std::error::Error>> {
         // STD([1, 2, 3, 4, 5]) with ddof=1 = sqrt(2.5)
         let values = Float64Array::from(vec![1.0, 2.0, 3.0, 4.0, 5.0]);
-        let result = run_single_group_agg::<Float64Array>(&values, AggregationOp::STD { ddof: 1 })?;
+        let result = run_single_group_agg::<Float64Array>(&values, Aggregation::Std { ddof: 1 })?;
         let expected = (2.5_f64).sqrt();
         assert!((result.value(0) - expected).abs() < 1e-6);
         Ok(())
@@ -308,8 +414,16 @@ mod tests {
     fn test_nunique() -> std::result::Result<(), Box<dyn std::error::Error>> {
         // NUNIQUE([1, 2, 2, 3, 3, 3]) = 3
         let values = Int32Array::from(vec![1, 2, 2, 3, 3, 3]);
-        let result = run_single_group_agg::<Int32Array>(&values, AggregationOp::NUNIQUE)?;
+        let result = run_single_group_agg::<Int32Array>(&values, Aggregation::NUnique)?;
         assert_eq!(result.value(0), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_nunique_all_includes_nulls() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let values = Int32Array::from(vec![Some(1), None, Some(1)]);
+        let result = run_single_group_agg::<Int32Array>(&values, Aggregation::NUniqueAll)?;
+        assert_eq!(result.value(0), 2);
         Ok(())
     }
 
@@ -317,7 +431,7 @@ mod tests {
     fn test_median() -> std::result::Result<(), Box<dyn std::error::Error>> {
         // MEDIAN([1, 2, 3, 4, 5]) = 3
         let values = Int32Array::from(vec![1, 2, 3, 4, 5]);
-        let result = run_single_group_agg::<Float64Array>(&values, AggregationOp::MEDIAN)?;
+        let result = run_single_group_agg::<Float64Array>(&values, Aggregation::Median)?;
         assert!((result.value(0) - 3.0).abs() < 1e-6);
         Ok(())
     }
@@ -333,12 +447,12 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![Field::new("key", DataType::Int32, false)]));
         let keys_batch = RecordBatch::try_new(schema, vec![Arc::new(keys)])?;
         let keys_table = crate::execute_cudf(CuDFTable::from_arrow_host(keys_batch))?;
-        let groupby = CuDFGroupBy::from_table_view(keys_table.into_view());
+        let groupby = keys_table.into_view().group_by_all();
 
-        let mut request = AggregationRequest::from_column_view(values_col.into_view());
-        request.add(AggregationOp::SUM.group_by());
-
-        let (result_keys, results) = crate::execute_cudf(groupby.aggregate([request]))?;
+        let result = crate::execute_cudf(
+            groupby.aggregate([GroupByRequest::new(values_col.into_view()).with(Aggregation::Sum)]),
+        )?;
+        let (result_keys, results) = result.into_parts();
 
         assert_eq!(result_keys.num_rows(), 2);
 
@@ -365,6 +479,60 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_group_by_selected_key_columns() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let values = Int32Array::from(vec![1, 2, 3, 10, 20]);
+        let keys = Int32Array::from(vec![1, 1, 1, 2, 2]);
+        let ignored = Int32Array::from(vec![9, 8, 7, 6, 5]);
+
+        let values_col = crate::execute_cudf(CuDFColumn::from_arrow_host(&values))?;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Int32, false),
+            Field::new("ignored", DataType::Int32, false),
+        ]));
+        let keys_batch = RecordBatch::try_new(schema, vec![Arc::new(keys), Arc::new(ignored)])?;
+        let keys_table = crate::execute_cudf(CuDFTable::from_arrow_host(keys_batch))?;
+        let groupby = keys_table.into_view().group_by(&[0])?;
+
+        let result = crate::execute_cudf(
+            groupby.aggregate([GroupByRequest::new(values_col.into_view()).with(Aggregation::Sum)]),
+        )?;
+
+        assert_eq!(result.keys().num_rows(), 2);
+        assert_eq!(result.keys().num_columns(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_request_list_is_rejected() -> std::result::Result<(), Box<dyn std::error::Error>>
+    {
+        let keys = Int32Array::from(vec![1, 1, 1]);
+        let keys_table = make_keys_table(&keys)?;
+        let groupby = keys_table.into_view().group_by_all();
+
+        let result = crate::execute_cudf(groupby.aggregate([]));
+
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_request_aggregation_list_is_rejected(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let values = Int32Array::from(vec![1, 2, 3]);
+        let keys = Int32Array::from(vec![1, 1, 1]);
+
+        let values_col = crate::execute_cudf(CuDFColumn::from_arrow_host(&values))?;
+        let keys_table = make_keys_table(&keys)?;
+        let groupby = keys_table.into_view().group_by_all();
+
+        let result =
+            crate::execute_cudf(groupby.aggregate([GroupByRequest::new(values_col.into_view())]));
+
+        assert!(result.is_err());
+        Ok(())
+    }
+
     fn make_keys_table(keys: &dyn Array) -> Result<CuDFTable> {
         let schema = Arc::new(Schema::new(vec![Field::new(
             "key",
@@ -378,19 +546,19 @@ mod tests {
 
     fn run_single_group_agg<T: Array + Clone + 'static>(
         values: &dyn Array,
-        agg_op: AggregationOp,
+        aggregation: Aggregation,
     ) -> Result<Arc<T>> {
         let n = values.len();
         let keys = Int32Array::from(vec![1; n]);
 
         let values_col = crate::execute_cudf(CuDFColumn::from_arrow_host(values))?;
         let keys_table = make_keys_table(&keys)?;
-        let groupby = CuDFGroupBy::from_table_view(keys_table.into_view());
+        let groupby = keys_table.into_view().group_by_all();
 
-        let mut request = AggregationRequest::from_column_view(values_col.into_view());
-        request.add(agg_op.group_by());
-
-        let (_result_keys, results) = crate::execute_cudf(groupby.aggregate([request]))?;
+        let (_result_keys, results) = crate::execute_cudf(
+            groupby.aggregate([GroupByRequest::new(values_col.into_view()).with(aggregation)]),
+        )?
+        .into_parts();
         let result_col = results
             .into_iter()
             .next()

--- a/src/table_view.rs
+++ b/src/table_view.rs
@@ -3,7 +3,8 @@ use crate::execution_policy;
 use crate::sort;
 use crate::stream_readiness::{CuDFStreamReady, CuDFTableReadiness};
 use crate::{
-    CuDFColumn, CuDFColumnView, CuDFError, CuDFOperation, CuDFTable, CuDFViewStorage, SortOrder,
+    CuDFColumn, CuDFColumnView, CuDFError, CuDFGroupBy, CuDFOperation, CuDFTable, CuDFViewStorage,
+    SortOrder,
 };
 use arrow_schema::ArrowError;
 use cxx::UniquePtr;
@@ -15,9 +16,10 @@ use std::sync::Arc;
 /// This is a safe wrapper around cuDF's table_view type.
 /// Views provide a lightweight way to reference table data without ownership.
 pub struct CuDFTableView {
-    // Keep backing storage alive so the view remains valid.
-    storage: Option<CuDFViewStorage>,
+    // Non-owning cuDF view. Keep this before `storage` so it drops first.
     inner: UniquePtr<ffi::TableView>,
+    // Backing owner for the buffers referenced by `inner`.
+    storage: Option<CuDFViewStorage>,
     stream_readiness: CuDFTableReadiness,
 }
 
@@ -28,8 +30,8 @@ impl CuDFTableView {
         stream_readiness: CuDFTableReadiness,
     ) -> Self {
         Self {
-            storage,
             inner,
+            storage,
             stream_readiness,
         }
     }
@@ -95,8 +97,8 @@ impl CuDFTableView {
         let num_columns = inner.num_columns();
         let storage: CuDFViewStorage = Arc::new(storage);
         Ok(Self {
-            storage: Some(storage),
             inner,
+            storage: Some(storage),
             stream_readiness: CuDFTableReadiness::columns(dependencies, num_columns),
         })
     }
@@ -247,6 +249,24 @@ impl CuDFTableView {
             Some(storage),
             CuDFTableReadiness::columns(dependencies, indices.len()),
         ))
+    }
+
+    /// Build a group-by operation from selected key columns.
+    ///
+    /// Rows with matching values in `key_columns` are grouped together.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any selected key column index is out of bounds.
+    pub fn group_by(&self, key_columns: &[usize]) -> Result<CuDFGroupBy, CuDFError> {
+        Ok(CuDFGroupBy::from_table_view(
+            self.select_columns(key_columns)?,
+        ))
+    }
+
+    /// Build a group-by operation using every column in this view as a key.
+    pub fn group_by_all(&self) -> CuDFGroupBy {
+        CuDFGroupBy::from_table_view(self.clone())
     }
 
     fn checked_column_index(&self, index: usize) -> Result<i32, CuDFError> {
@@ -473,8 +493,8 @@ impl CuDFTableView {
 impl Clone for CuDFTableView {
     fn clone(&self) -> Self {
         Self {
-            storage: self.storage.clone(),
             inner: self.inner.clone(),
+            storage: self.storage.clone(),
             stream_readiness: self.stream_readiness.clone(),
         }
     }


### PR DESCRIPTION
## Summary

- Redesign the root `CuDFGroupBy` aggregation API around `GroupByRequest`, `Aggregation`, and `CuDFGroupByResult`.
- Update DataFusion aggregate planning to build the new request type and consume flattened grouped results.
- Fix group-by/view lifetime ordering so non-owning cuDF handles drop before their backing storage, and retain group-by destruction readiness after aggregation.

## Root Cause

The previous group-by wrapper exposed a less composable request API and returned raw nested tuples. While adding NUNIQUE and MEDIAN coverage, cleanup crashes exposed a wrapper lifetime issue: cuDF groupby/view handles could be dropped after the Rust-owned key/view storage or producer stream readiness they depended on.

## Validation

- `cargo test --workspace`
